### PR TITLE
expose load dev files via HTTP

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:init-fn |app.server/main!) (:port 6001) (:reload-fn |app.server/reload!) (:version |0.6.32)
+  :configs $ {} (:init-fn |app.server/main!) (:port 6001) (:reload-fn |app.server/reload!) (:version |0.6.33)
     :modules $ [] |lilac/ |memof/ |recollect/ |cumulo-util.calcit/ |ws-edn.calcit/ |bisection-key/
   :entries $ {}
     :client $ {} (:init-fn |app.client/main!) (:reload-fn |app.client/reload!)
@@ -17208,6 +17208,10 @@
                     :data $ {}
                       |T $ {} (:at 1546166217613) (:by |root) (:text |:port) (:type :leaf)
                       |j $ {} (:at 1546166219604) (:by |root) (:text |6001) (:type :leaf)
+                  |w $ {} (:at 1546166216699) (:by |root) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1678516111477) (:by |S1lNv50FW) (:text |:expose-port) (:type :leaf)
+                      |j $ {} (:at 1678516112576) (:by |S1lNv50FW) (:text |6011) (:type :leaf)
                   |yT $ {} (:at 1599733029770) (:by |S1lNv50FW) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1599733031450) (:by |S1lNv50FW) (:text |:init-fn) (:type :leaf)
@@ -17765,6 +17769,298 @@
                               |x $ {} (:at 1625813137355) (:by |S1lNv50FW) (:text |d2!) (:type :leaf)
                               |y $ {} (:at 1625813137355) (:by |S1lNv50FW) (:text |true) (:type :leaf)
                               |yT $ {} (:at 1625813137355) (:by |S1lNv50FW) (:text |op-data) (:type :leaf)
+          |expose-files! $ {} (:at 1678516206678) (:by |S1lNv50FW) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1678516206678) (:by |S1lNv50FW) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1678516206678) (:by |S1lNv50FW) (:text |expose-files!) (:type :leaf)
+              |h $ {} (:at 1678516206678) (:by |S1lNv50FW) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1678516210412) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+              |l $ {} (:at 1678516616317) (:by |S1lNv50FW) (:type :expr)
+                :data $ {}
+                  |D $ {} (:at 1678516616887) (:by |S1lNv50FW) (:text |let) (:type :leaf)
+                  |T $ {} (:at 1678516617352) (:by |S1lNv50FW) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1678516617780) (:by |S1lNv50FW) (:type :expr)
+                        :data $ {}
+                          |D $ {} (:at 1678516618886) (:by |S1lNv50FW) (:text |server) (:type :leaf)
+                          |T $ {} (:at 1678516211469) (:by |S1lNv50FW) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1678516232379) (:by |S1lNv50FW) (:text |createServer) (:type :leaf)
+                              |b $ {} (:at 1678516237782) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678516238749) (:by |S1lNv50FW) (:text |fn) (:type :leaf)
+                                  |b $ {} (:at 1678516239081) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678516239543) (:by |S1lNv50FW) (:text |req) (:type :leaf)
+                                      |b $ {} (:at 1678516245002) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                  |e $ {} (:at 1678517380339) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678517382559) (:by |S1lNv50FW) (:text |hint-fn) (:type :leaf)
+                                      |b $ {} (:at 1678517383492) (:by |S1lNv50FW) (:text |async) (:type :leaf)
+                                  |h $ {} (:at 1678516245942) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |D $ {} (:at 1678518294050) (:by |S1lNv50FW) (:text |;) (:type :leaf)
+                                      |T $ {} (:at 1678516249591) (:by |S1lNv50FW) (:text |js/console.log) (:type :leaf)
+                                      |h $ {} (:at 1678516251731) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678516253038) (:by |S1lNv50FW) (:text |.-url) (:type :leaf)
+                                          |b $ {} (:at 1678516253827) (:by |S1lNv50FW) (:text |req) (:type :leaf)
+                                      |l $ {} (:at 1678516258386) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678518272615) (:by |S1lNv50FW) (:text |.-headers) (:type :leaf)
+                                          |b $ {} (:at 1678516261412) (:by |S1lNv50FW) (:text |req) (:type :leaf)
+                                  |k $ {} (:at 1678518175726) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678518175726) (:by |S1lNv50FW) (:text |.!setHeader) (:type :leaf)
+                                      |X $ {} (:at 1678518191474) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                      |b $ {} (:at 1678518701293) (:by |S1lNv50FW) (:text "|\"Access-Control-Allow-Origin") (:type :leaf)
+                                      |h $ {} (:at 1678518490965) (:by |S1lNv50FW) (:text "|\"*") (:type :leaf)
+                                  |kT $ {} (:at 1678518175726) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678518175726) (:by |S1lNv50FW) (:text |.!setHeader) (:type :leaf)
+                                      |X $ {} (:at 1678518191474) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                      |b $ {} (:at 1678518675082) (:by |S1lNv50FW) (:text "|\"Access-Control-Allow-Headers") (:type :leaf)
+                                      |h $ {} (:at 1678518490965) (:by |S1lNv50FW) (:text "|\"*") (:type :leaf)
+                                  |l $ {} (:at 1678518800355) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |D $ {} (:at 1678518801009) (:by |S1lNv50FW) (:text |if) (:type :leaf)
+                                      |L $ {} (:at 1678518808532) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1678518809058) (:by |S1lNv50FW) (:text |=) (:type :leaf)
+                                          |L $ {} (:at 1678518978995) (:by |S1lNv50FW) (:text "|\"OPTIONS") (:type :leaf)
+                                          |T $ {} (:at 1678518801399) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678518803127) (:by |S1lNv50FW) (:text |.-method) (:type :leaf)
+                                              |b $ {} (:at 1678518803951) (:by |S1lNv50FW) (:text |req) (:type :leaf)
+                                      |P $ {} (:at 1678518885186) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                          |b $ {} (:at 1678518885186) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                              |b $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                              |h $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text |200) (:type :leaf)
+                                          |h $ {} (:at 1678518885186) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                              |b $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                              |h $ {} (:at 1678518885186) (:by |S1lNv50FW) (:text "|\"OK") (:type :leaf)
+                                      |T $ {} (:at 1678516866950) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678516876201) (:by |S1lNv50FW) (:text |case-default) (:type :leaf)
+                                          |b $ {} (:at 1678516879992) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678516879992) (:by |S1lNv50FW) (:text |.-url) (:type :leaf)
+                                              |b $ {} (:at 1678516879992) (:by |S1lNv50FW) (:text |req) (:type :leaf)
+                                          |h $ {} (:at 1678517923965) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |D $ {} (:at 1678517924658) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                              |P $ {} (:at 1678517939908) (:by |S1lNv50FW) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1678517939908) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                                  |b $ {} (:at 1678517939908) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                  |h $ {} (:at 1678517943315) (:by |S1lNv50FW) (:text |404) (:type :leaf)
+                                              |b $ {} (:at 1678517929590) (:by |S1lNv50FW) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1678517929590) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                  |b $ {} (:at 1678517929590) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                  |h $ {} (:at 1678517957735) (:by |S1lNv50FW) (:text "|\"not found. check url") (:type :leaf)
+                                          |l $ {} (:at 1678516904026) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678516904965) (:by |S1lNv50FW) (:text "|\"/") (:type :leaf)
+                                              |b $ {} (:at 1678516907083) (:by |S1lNv50FW) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1678516909012) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                  |b $ {} (:at 1678516910196) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                  |h $ {} (:at 1678516971818) (:by |S1lNv50FW) (:text "|\"echo from Calcit Editor") (:type :leaf)
+                                          |m $ {} (:at 1678517734791) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678517737860) (:by |S1lNv50FW) (:text "|\"/favicon.ico") (:type :leaf)
+                                              |b $ {} (:at 1678517741469) (:by |S1lNv50FW) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1678517741469) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                                  |h $ {} (:at 1678517741469) (:by |S1lNv50FW) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1678517741469) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                                      |b $ {} (:at 1678517741469) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                      |h $ {} (:at 1678517745885) (:by |S1lNv50FW) (:text |404) (:type :leaf)
+                                                  |l $ {} (:at 1678517741469) (:by |S1lNv50FW) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1678517741469) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                      |b $ {} (:at 1678517741469) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                      |h $ {} (:at 1678517747841) (:by |S1lNv50FW) (:text "|\"") (:type :leaf)
+                                          |o $ {} (:at 1678516972790) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |F $ {} (:at 1678517290540) (:by |S1lNv50FW) (:text "|\"/load-error") (:type :leaf)
+                                              |b $ {} (:at 1678516980186) (:by |S1lNv50FW) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1678516982326) (:by |S1lNv50FW) (:text |readFile) (:type :leaf)
+                                                  |X $ {} (:at 1678517294134) (:by |S1lNv50FW) (:text "|\"./.calcit-error.cirru") (:type :leaf)
+                                                  |b $ {} (:at 1678516984802) (:by |S1lNv50FW) (:text "|\"utf8") (:type :leaf)
+                                                  |h $ {} (:at 1678516986117) (:by |S1lNv50FW) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1678516986491) (:by |S1lNv50FW) (:text |fn) (:type :leaf)
+                                                      |b $ {} (:at 1678516987252) (:by |S1lNv50FW) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1678516987835) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                                                          |X $ {} (:at 1678517561279) (:by |S1lNv50FW) (:text |?) (:type :leaf)
+                                                          |b $ {} (:at 1678516989701) (:by |S1lNv50FW) (:text |content) (:type :leaf)
+                                                      |h $ {} (:at 1678516991655) (:by |S1lNv50FW) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1678516992047) (:by |S1lNv50FW) (:text |if) (:type :leaf)
+                                                          |b $ {} (:at 1678516992656) (:by |S1lNv50FW) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1678516993940) (:by |S1lNv50FW) (:text |some?) (:type :leaf)
+                                                              |b $ {} (:at 1678516994616) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                                                          |h $ {} (:at 1678517649131) (:by |S1lNv50FW) (:type :expr)
+                                                            :data $ {}
+                                                              |D $ {} (:at 1678517650376) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                                              |b $ {} (:at 1678517651108) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517662635) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                                                  |b $ {} (:at 1678517662635) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517665613) (:by |S1lNv50FW) (:text |400) (:type :leaf)
+                                                              |h $ {} (:at 1678517666469) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517671837) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                                  |b $ {} (:at 1678517673057) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517698422) (:by |S1lNv50FW) (:type :expr)
+                                                                    :data $ {}
+                                                                      |T $ {} (:at 1678517702889) (:by |S1lNv50FW) (:text |format-cirru-edn) (:type :leaf)
+                                                                      |b $ {} (:at 1678517703173) (:by |S1lNv50FW) (:type :expr)
+                                                                        :data $ {}
+                                                                          |T $ {} (:at 1678517703513) (:by |S1lNv50FW) (:text |{}) (:type :leaf)
+                                                                          |b $ {} (:at 1678517703907) (:by |S1lNv50FW) (:type :expr)
+                                                                            :data $ {}
+                                                                              |T $ {} (:at 1678517705009) (:by |S1lNv50FW) (:text |:message) (:type :leaf)
+                                                                              |b $ {} (:at 1678517705434) (:by |S1lNv50FW) (:type :expr)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:at 1678517706183) (:by |S1lNv50FW) (:text |str) (:type :leaf)
+                                                                                  |b $ {} (:at 1678517706863) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                                                          |l $ {} (:at 1678517031982) (:by |S1lNv50FW) (:type :expr)
+                                                            :data $ {}
+                                                              |D $ {} (:at 1678517032526) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                                              |H $ {} (:at 1678517622520) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517622520) (:by |S1lNv50FW) (:text |.!setHeader) (:type :leaf)
+                                                                  |b $ {} (:at 1678517622520) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517622520) (:by |S1lNv50FW) (:text "|\"Content-Type") (:type :leaf)
+                                                                  |l $ {} (:at 1678517791864) (:by |S1lNv50FW) (:text "|\"text/plain") (:type :leaf)
+                                                              |L $ {} (:at 1678517033547) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517037200) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                                                  |b $ {} (:at 1678517039750) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517040292) (:by |S1lNv50FW) (:text |200) (:type :leaf)
+                                                              |T $ {} (:at 1678516999528) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517008675) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                                  |b $ {} (:at 1678517016759) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |l $ {} (:at 1678517019111) (:by |S1lNv50FW) (:text |content) (:type :leaf)
+                                          |q $ {} (:at 1678516972790) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678517121245) (:by |S1lNv50FW) (:text "|\"/load-compact") (:type :leaf)
+                                              |b $ {} (:at 1678516980186) (:by |S1lNv50FW) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1678516982326) (:by |S1lNv50FW) (:text |readFile) (:type :leaf)
+                                                  |X $ {} (:at 1678517131443) (:by |S1lNv50FW) (:text "|\"./compact.cirru") (:type :leaf)
+                                                  |b $ {} (:at 1678516984802) (:by |S1lNv50FW) (:text "|\"utf8") (:type :leaf)
+                                                  |h $ {} (:at 1678516986117) (:by |S1lNv50FW) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1678516986491) (:by |S1lNv50FW) (:text |fn) (:type :leaf)
+                                                      |b $ {} (:at 1678516987252) (:by |S1lNv50FW) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1678516987835) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                                                          |X $ {} (:at 1678517564000) (:by |S1lNv50FW) (:text |?) (:type :leaf)
+                                                          |b $ {} (:at 1678516989701) (:by |S1lNv50FW) (:text |content) (:type :leaf)
+                                                      |h $ {} (:at 1678516991655) (:by |S1lNv50FW) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1678516992047) (:by |S1lNv50FW) (:text |if) (:type :leaf)
+                                                          |b $ {} (:at 1678516992656) (:by |S1lNv50FW) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1678516993940) (:by |S1lNv50FW) (:text |some?) (:type :leaf)
+                                                              |b $ {} (:at 1678516994616) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                                                          |h $ {} (:at 1678517710762) (:by |S1lNv50FW) (:type :expr)
+                                                            :data $ {}
+                                                              |D $ {} (:at 1678517711269) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                                              |X $ {} (:at 1678517719152) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517719152) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                                                  |b $ {} (:at 1678517719152) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517719152) (:by |S1lNv50FW) (:text |400) (:type :leaf)
+                                                              |b $ {} (:at 1678517712909) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                                  |b $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517712909) (:by |S1lNv50FW) (:type :expr)
+                                                                    :data $ {}
+                                                                      |T $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |format-cirru-edn) (:type :leaf)
+                                                                      |b $ {} (:at 1678517712909) (:by |S1lNv50FW) (:type :expr)
+                                                                        :data $ {}
+                                                                          |T $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |{}) (:type :leaf)
+                                                                          |b $ {} (:at 1678517712909) (:by |S1lNv50FW) (:type :expr)
+                                                                            :data $ {}
+                                                                              |T $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |:message) (:type :leaf)
+                                                                              |b $ {} (:at 1678517712909) (:by |S1lNv50FW) (:type :expr)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |str) (:type :leaf)
+                                                                                  |b $ {} (:at 1678517712909) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                                                          |l $ {} (:at 1678517031982) (:by |S1lNv50FW) (:type :expr)
+                                                            :data $ {}
+                                                              |D $ {} (:at 1678517032526) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                                              |P $ {} (:at 1678517794712) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517794712) (:by |S1lNv50FW) (:text |.!setHeader) (:type :leaf)
+                                                                  |b $ {} (:at 1678517794712) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517794712) (:by |S1lNv50FW) (:text "|\"Content-Type") (:type :leaf)
+                                                                  |l $ {} (:at 1678517794712) (:by |S1lNv50FW) (:text "|\"text/plain") (:type :leaf)
+                                                              |R $ {} (:at 1678517618796) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517618796) (:by |S1lNv50FW) (:text |.!writeHead) (:type :leaf)
+                                                                  |b $ {} (:at 1678517618796) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |h $ {} (:at 1678517618796) (:by |S1lNv50FW) (:text |200) (:type :leaf)
+                                                              |T $ {} (:at 1678516999528) (:by |S1lNv50FW) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1678517008675) (:by |S1lNv50FW) (:text |.!end) (:type :leaf)
+                                                                  |b $ {} (:at 1678517016759) (:by |S1lNv50FW) (:text |res) (:type :leaf)
+                                                                  |l $ {} (:at 1678517019111) (:by |S1lNv50FW) (:text |content) (:type :leaf)
+                  |b $ {} (:at 1678516619952) (:by |S1lNv50FW) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1678516622504) (:by |S1lNv50FW) (:text |.!listen) (:type :leaf)
+                      |b $ {} (:at 1678516623034) (:by |S1lNv50FW) (:text |server) (:type :leaf)
+                      |h $ {} (:at 1678516626596) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                      |o $ {} (:at 1678516631210) (:by |S1lNv50FW) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1678516631664) (:by |S1lNv50FW) (:text |fn) (:type :leaf)
+                          |b $ {} (:at 1678516632172) (:by |S1lNv50FW) (:type :expr)
+                            :data $ {}
+                          |h $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |let) (:type :leaf)
+                              |b $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |link) (:type :leaf)
+                                      |b $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |.!blue) (:type :leaf)
+                                          |b $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |chalk) (:type :leaf)
+                                          |h $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |str) (:type :leaf)
+                                              |b $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text "|\"http://localhost:") (:type :leaf)
+                                              |h $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                              |h $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |println) (:type :leaf)
+                                  |b $ {} (:at 1678518016670) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |str) (:type :leaf)
+                                      |b $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text "|\"port ") (:type :leaf)
+                                      |h $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                                      |l $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text "|\" ok, local configs exposed on ") (:type :leaf)
+                                      |o $ {} (:at 1678518016670) (:by |S1lNv50FW) (:text |link) (:type :leaf)
           |initial-db $ {} (:at 1546165527792) (:by |root) (:type :expr)
             :data $ {}
               |T $ {} (:at 1625771173258) (:by |S1lNv50FW) (:text |def) (:type :leaf)
@@ -18202,6 +18498,30 @@
                           |T $ {} (:at 1546179898368) (:by |root) (:text |run-server!) (:type :leaf)
                           |j $ {} (:at 1546179898368) (:by |root) (:text |dispatch!) (:type :leaf)
                           |r $ {} (:at 1546179907783) (:by |root) (:text |unoccupied-port) (:type :leaf)
+              |vj $ {} (:at 1546179890407) (:by |root) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1678516352940) (:by |S1lNv50FW) (:text |pick-http-port!) (:type :leaf)
+                  |j $ {} (:at 1678516292400) (:by |S1lNv50FW) (:type :expr)
+                    :data $ {}
+                      |D $ {} (:at 1678516295425) (:by |S1lNv50FW) (:text |either) (:type :leaf)
+                      |T $ {} (:at 1546179903699) (:by |root) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1678516166985) (:by |S1lNv50FW) (:text |:expose-port) (:type :leaf)
+                          |j $ {} (:at 1546179903699) (:by |root) (:text |configs) (:type :leaf)
+                      |b $ {} (:at 1678516310396) (:by |S1lNv50FW) (:type :expr)
+                        :data $ {}
+                          |D $ {} (:at 1678516312943) (:by |S1lNv50FW) (:text |:expose-port) (:type :leaf)
+                          |T $ {} (:at 1678516319629) (:by |S1lNv50FW) (:text |schema/configs) (:type :leaf)
+                  |r $ {} (:at 1546179890407) (:by |root) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1546179890407) (:by |root) (:text |fn) (:type :leaf)
+                      |j $ {} (:at 1546179890407) (:by |root) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1546179890407) (:by |root) (:text |unoccupied-port) (:type :leaf)
+                      |r $ {} (:at 1546179898368) (:by |root) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1678516184437) (:by |S1lNv50FW) (:text |expose-files!) (:type :leaf)
+                          |r $ {} (:at 1546179907783) (:by |root) (:text |unoccupied-port) (:type :leaf)
               |w $ {} (:at 1504777570689) (:type :expr)
                 :data $ {}
                   |T $ {} (:at 1504777570689) (:by |root) (:text |render-loop!) (:type :leaf)
@@ -18630,6 +18950,7 @@
                     |v $ {} (:at 1504777570689) (:type :expr)
                       :data $ {}
                         |r $ {} (:at 1546164261255) (:by |root) (:text |pick-port!) (:type :leaf)
+                        |t $ {} (:at 1678516490234) (:by |S1lNv50FW) (:text |pick-http-port!) (:type :leaf)
                 |yn $ {} (:at 1512706406626) (:author |SJhrjuzlG) (:type :expr)
                   :data $ {}
                     |j $ {} (:at 1512706409457) (:author |SJhrjuzlG) (:text |app.util) (:type :leaf)
@@ -18663,6 +18984,20 @@
                     |j $ {} (:at 1512708354816) (:author |SJhrjuzlG) (:text ||gaze) (:type :leaf)
                     |r $ {} (:at 1625727124237) (:author |SJhrjuzlG) (:by |S1lNv50FW) (:text |:default) (:type :leaf)
                     |v $ {} (:at 1512708355973) (:author |SJhrjuzlG) (:text |gaze) (:type :leaf)
+                |yyu $ {} (:at 1678516216134) (:by |S1lNv50FW) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1678516219302) (:by |S1lNv50FW) (:text "|\"node:http") (:type :leaf)
+                    |b $ {} (:at 1678516221566) (:by |S1lNv50FW) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1678516222034) (:by |S1lNv50FW) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1678516230505) (:by |S1lNv50FW) (:text |createServer) (:type :leaf)
+                |yyv $ {} (:at 1678516857896) (:by |S1lNv50FW) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1678516859448) (:by |S1lNv50FW) (:text "|\"node:fs") (:type :leaf)
+                    |b $ {} (:at 1678516862485) (:by |S1lNv50FW) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1678516863714) (:by |S1lNv50FW) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1678516864878) (:by |S1lNv50FW) (:text |readFile) (:type :leaf)
                 |yyx $ {} (:at 1546107117288) (:by |root) (:type :expr)
                   :data $ {}
                     |j $ {} (:at 1546107117288) (:by |root) (:text |ws-edn.server) (:type :leaf)
@@ -33217,6 +33552,7 @@
                         :data $ {}
                           |T $ {} (:at 1625727953737) (:by |S1lNv50FW) (:text |.!listen) (:type :leaf)
                           |j $ {} (:at 1507172895497) (:by |root) (:text |port) (:type :leaf)
+                          |n $ {} (:at 1678521404824) (:by |S1lNv50FW) (:text "|\"0.0.0.0") (:type :leaf)
         :ns $ {} (:at 1507172643129) (:by |root) (:type :expr)
           :data $ {}
             |T $ {} (:at 1507172643129) (:by |root) (:text |ns) (:type :leaf)
@@ -33616,6 +33952,71 @@
                     :data $ {}
                       |T $ {} (:at 1650734480504) (:by |S1lNv50FW) (:text |:op) (:type :leaf)
                       |j $ {} (:at 1647019200250) (:by |S1lNv50FW) (:text |js/process.env.op) (:type :leaf)
+          |pick-http-port! $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |pick-http-port!) (:type :leaf)
+              |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                  |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |next-fn) (:type :leaf)
+              |l $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1678520701264) (:by |S1lNv50FW) (:text |port-taken?) (:type :leaf)
+                  |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                  |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |fn) (:type :leaf)
+                      |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                          |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |taken?) (:type :leaf)
+                      |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |if) (:type :leaf)
+                          |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |some?) (:type :leaf)
+                              |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                          |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                              |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |js/console.error) (:type :leaf)
+                                  |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |err) (:type :leaf)
+                              |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |js/process.exit) (:type :leaf)
+                                  |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |1) (:type :leaf)
+                          |l $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |if) (:type :leaf)
+                              |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |taken?) (:type :leaf)
+                              |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |do) (:type :leaf)
+                                  |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |println) (:type :leaf)
+                                      |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |str) (:type :leaf)
+                                          |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text "|\"port ") (:type :leaf)
+                                          |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                                          |l $ {} (:at 1678516534447) (:by |S1lNv50FW) (:text "|\" in use.") (:type :leaf)
+                                  |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |pick-http-port!) (:type :leaf)
+                                      |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |inc) (:type :leaf)
+                                          |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |port) (:type :leaf)
+                                      |h $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |next-fn) (:type :leaf)
+                              |l $ {} (:at 1678516491771) (:by |S1lNv50FW) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |next-fn) (:type :leaf)
+                                  |b $ {} (:at 1678516491771) (:by |S1lNv50FW) (:text |port) (:type :leaf)
           |pick-port! $ {} (:at 1518923396797) (:by |root) (:type :expr)
             :data $ {}
               |T $ {} (:at 1518923396797) (:by |root) (:text |defn) (:type :leaf)
@@ -33668,7 +34069,7 @@
                                           |T $ {} (:at 1625724460857) (:by |S1lNv50FW) (:text |str) (:type :leaf)
                                           |j $ {} (:at 1625724467354) (:by |S1lNv50FW) (:text "|\"port ") (:type :leaf)
                                           |n $ {} (:at 1625724468610) (:by |S1lNv50FW) (:text |port) (:type :leaf)
-                                          |r $ {} (:at 1625724463780) (:by |S1lNv50FW) (:text "|\" is in use.") (:type :leaf)
+                                          |r $ {} (:at 1678516543441) (:by |S1lNv50FW) (:text "|\" in use.") (:type :leaf)
                                   |j $ {} (:at 1518923586499) (:by |root) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1518923590284) (:by |root) (:text |pick-port!) (:type :leaf)
@@ -33705,7 +34106,7 @@
                                               |D $ {} (:at 1625724633619) (:by |S1lNv50FW) (:text |str) (:type :leaf)
                                               |L $ {} (:at 1625724493603) (:by |S1lNv50FW) (:text "|\"port ") (:type :leaf)
                                               |Q $ {} (:at 1625724494316) (:by |S1lNv50FW) (:text |port) (:type :leaf)
-                                              |V $ {} (:at 1625724490504) (:by |S1lNv50FW) (:text "|\" is ok, please edit on ") (:type :leaf)
+                                              |V $ {} (:at 1678516541183) (:by |S1lNv50FW) (:text "|\" ok, please edit on ") (:type :leaf)
                                               |f $ {} (:at 1625724484939) (:by |S1lNv50FW) (:text |link) (:type :leaf)
                                   |j $ {} (:at 1518923725832) (:by |root) (:type :expr)
                                     :data $ {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/editor",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "description": "Calcit Editor",
   "bin": {
     "ct": "./server.mjs"
@@ -32,6 +32,6 @@
     "latest-version": "^7.0.0",
     "md5": "^2.3.0",
     "nanoid": "^4.0.1",
-    "ws": "^8.12.1"
+    "ws": "^8.13.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz#c5a1a4bfe1b57f0c3e61b29883525c6da3e5c091"
   integrity sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==
 
+"@pnpm/config.env-replace@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz#c76fa65847c9554e88d910f264c2ba9a1575e833"
+  integrity sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==
+
 "@pnpm/network.ca-file@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz#2ab05e09c1af0cdf2fcf5035bea1484e222f7983"
@@ -143,11 +148,12 @@
   dependencies:
     graceful-fs "4.2.10"
 
-"@pnpm/npm-conf@^1.0.4":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@pnpm/npm-conf/-/npm-conf-1.0.5.tgz#3475541fb71d7b6ce68acaaa3392eae9fedf3276"
-  integrity sha512-hD8ml183638O3R6/Txrh0L8VzGOrFXgRtRDG4qQC4tONdZ5Z1M+tlUUDUvrjYdmK6G+JTBTeaCLMna11cXzi8A==
+"@pnpm/npm-conf@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@pnpm/npm-conf/-/npm-conf-2.1.0.tgz#1bbecd961a1ea447f209556728e2dcadddb0bca6"
+  integrity sha512-Oe6ntvgsMTE3hDIqy6sajqHF+MnzJrOF06qC2QSiUEybLL7cp6tjoKUa32gpd9+KPVl4QyMs3E3nsXrx/Vdnlw==
   dependencies:
+    "@pnpm/config.env-replace" "^1.0.0"
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
@@ -655,11 +661,11 @@ rc@1.2.8:
     strip-json-comments "~2.0.1"
 
 registry-auth-token@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.0.1.tgz#5e6cd106e6c251135a046650c58476fc03e92833"
-  integrity sha512-UfxVOj8seK1yaIOiieV4FIP01vfBDLsY0H9sQzi9EbbUdJiuuBjJgLa1DpImXMNPnVkBD4eVxTEXcrZA6kfpJA==
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.0.2.tgz#8b026cc507c8552ebbe06724136267e63302f756"
+  integrity sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==
   dependencies:
-    "@pnpm/npm-conf" "^1.0.4"
+    "@pnpm/npm-conf" "^2.1.0"
 
 registry-url@^6.0.0:
   version "6.0.1"
@@ -695,9 +701,9 @@ responselike@^3.0.0:
     lowercase-keys "^3.0.0"
 
 rollup@^3.10.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.18.0.tgz#2354ba63ba66d6a09c652c3ea0dbcd9dad72bbde"
-  integrity sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.19.1.tgz#2b3a31ac1ff9f3afab2e523fa687fef5b0ee20fc"
+  integrity sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -767,10 +773,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.12.1:
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
-  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
+ws@^8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
+  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
 x-is-array@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
expose files at `6011` port so that remote pages could load them. available paths are:

- `/load-compact` => `compact.cirru`
- `/load-error` => `.calcit-error.cirru`
