### PR TITLE
get `with-examples` form, which is a dirty trick

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {} (:package |app)
-  :configs $ {} (:init-fn |app.server/main!) (:port 6001) (:reload-fn |app.server/reload!) (:version |0.9.9)
+  :configs $ {} (:init-fn |app.server/main!) (:port 6001) (:reload-fn |app.server/reload!) (:version |0.9.10)
     :modules $ [] |lilac/ |memof/ |recollect/ |cumulo-util.calcit/ |ws-edn.calcit/ |bisection-key/ |respo-markdown.calcit/
   :entries $ {}
     :client $ {} (:init-fn |app.client/main!) (:reload-fn |app.client/reload!)
@@ -7073,6 +7073,7 @@
                                     :data $ {}
                                       |D $ %{} :Leaf (:at 1626160819721) (:by |N7iJQdd93) (:text |file->cirru)
                                       |T $ %{} :Leaf (:at 1611814768444) (:by |S1lNv50FW) (:text |file)
+                                      |b $ %{} :Leaf (:at 1758954277440) (:by |S1lNv50FW) (:text |false)
                   |T $ %{} :Expr (:at 1511261084856) (:by |root)
                     :data $ {}
                       |D $ %{} :Leaf (:at 1511261086449) (:by |root) (:text |comp-modal)
@@ -23472,6 +23473,18 @@
                   |b $ %{} :Leaf (:at 1692517019166) (:by |S1lNv50FW) (:text |:CodeEntry)
                   |h $ %{} :Leaf (:at 1692517037741) (:by |S1lNv50FW) (:text |:doc)
                   |l $ %{} :Leaf (:at 1692517038765) (:by |S1lNv50FW) (:text |:code)
+        |CodeEntryCompact $ %{} :CodeEntry (:doc "|another record for CodeEntry which only used in writing compact file")
+          :code $ %{} :Expr (:at 1758954084909) (:by |S1lNv50FW)
+            :data $ {}
+              |T $ %{} :Leaf (:at 1758954090977) (:by |S1lNv50FW) (:text |def)
+              |b $ %{} :Leaf (:at 1758954084909) (:by |S1lNv50FW) (:text |CodeEntryCompact)
+              |h $ %{} :Expr (:at 1758954086985) (:by |S1lNv50FW)
+                :data $ {}
+                  |T $ %{} :Leaf (:at 1758954086985) (:by |S1lNv50FW) (:text |new-record)
+                  |b $ %{} :Leaf (:at 1758954086985) (:by |S1lNv50FW) (:text |:CodeEntry)
+                  |h $ %{} :Leaf (:at 1758954086985) (:by |S1lNv50FW) (:text |:doc)
+                  |l $ %{} :Leaf (:at 1758954086985) (:by |S1lNv50FW) (:text |:code)
+                  |o $ %{} :Leaf (:at 1758954086985) (:by |S1lNv50FW) (:text |:examples)
         |FileEntry $ %{} :CodeEntry (:doc |)
           :code $ %{} :Expr (:at 1693239478083) (:by |S1lNv50FW)
             :data $ {}
@@ -40954,6 +40967,85 @@
                   |T $ %{} :Leaf (:at 1692515122148) (:by |S1lNv50FW) (:text |&record:matches?)
                   |f $ %{} :Leaf (:at 1692515129736) (:by |S1lNv50FW) (:text |schema/CirruExpr)
                   |r $ %{} :Leaf (:at 1504777570689) (:by |root) (:text |x)
+        |extract-examples-code $ %{} :CodeEntry (:doc |)
+          :code $ %{} :Expr (:at 1758952503057) (:by |S1lNv50FW)
+            :data $ {}
+              |T $ %{} :Leaf (:at 1758952503057) (:by |S1lNv50FW) (:text |defn)
+              |b $ %{} :Leaf (:at 1758952503057) (:by |S1lNv50FW) (:text |extract-examples-code)
+              |h $ %{} :Expr (:at 1758952503057) (:by |S1lNv50FW)
+                :data $ {}
+                  |T $ %{} :Leaf (:at 1758952505481) (:by |S1lNv50FW) (:text |xs)
+              |l $ %{} :Expr (:at 1758952506118) (:by |S1lNv50FW)
+                :data $ {}
+                  |T $ %{} :Leaf (:at 1758952506556) (:by |S1lNv50FW) (:text |if)
+                  |b $ %{} :Expr (:at 1758952507545) (:by |S1lNv50FW)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1758954657388) (:by |S1lNv50FW) (:text |&=)
+                      |X $ %{} :Leaf (:at 1758952519584) (:by |S1lNv50FW) (:text "|\"with-examples")
+                      |b $ %{} :Expr (:at 1758952508704) (:by |S1lNv50FW)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1758952512614) (:by |S1lNv50FW) (:text |&list:nth)
+                          |b $ %{} :Leaf (:at 1758952513407) (:by |S1lNv50FW) (:text |xs)
+                          |h $ %{} :Leaf (:at 1758952514368) (:by |S1lNv50FW) (:text |0)
+                  |h $ %{} :Expr (:at 1758952548992) (:by |S1lNv50FW)
+                    :data $ {}
+                      |D $ %{} :Leaf (:at 1758954807797) (:by |S1lNv50FW) (:text |let)
+                      |H $ %{} :Expr (:at 1758954808995) (:by |S1lNv50FW)
+                        :data $ {}
+                          |T $ %{} :Expr (:at 1758954809109) (:by |S1lNv50FW)
+                            :data $ {}
+                              |D $ %{} :Leaf (:at 1758954813554) (:by |S1lNv50FW) (:text |examples)
+                              |T $ %{} :Expr (:at 1758954808278) (:by |S1lNv50FW)
+                                :data $ {}
+                                  |T $ %{} :Leaf (:at 1758954808278) (:by |S1lNv50FW) (:text |&list:nth)
+                                  |b $ %{} :Leaf (:at 1758954808278) (:by |S1lNv50FW) (:text |xs)
+                                  |h $ %{} :Leaf (:at 1758954808278) (:by |S1lNv50FW) (:text |1)
+                      |L $ %{} :Expr (:at 1758952549905) (:by |S1lNv50FW)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1758952553005) (:by |S1lNv50FW) (:text |assert=)
+                          |b $ %{} :Leaf (:at 1758953017271) (:by |S1lNv50FW) (:text |3)
+                          |h $ %{} :Expr (:at 1758952555954) (:by |S1lNv50FW)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1758952561210) (:by |S1lNv50FW) (:text |&list:count)
+                              |b $ %{} :Leaf (:at 1758952557420) (:by |S1lNv50FW) (:text |xs)
+                      |P $ %{} :Expr (:at 1758954682691) (:by |S1lNv50FW)
+                        :data $ {}
+                          |D $ %{} :Leaf (:at 1758954683197) (:by |S1lNv50FW) (:text |if)
+                          |L $ %{} :Expr (:at 1758954684354) (:by |S1lNv50FW)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1758954757934) (:by |S1lNv50FW) (:text |not=)
+                              |X $ %{} :Leaf (:at 1758954761016) (:by |S1lNv50FW) (:text "|\"do")
+                              |b $ %{} :Expr (:at 1758954687961) (:by |S1lNv50FW)
+                                :data $ {}
+                                  |D $ %{} :Leaf (:at 1758954693649) (:by |S1lNv50FW) (:text |&list:nth)
+                                  |P $ %{} :Leaf (:at 1758954839544) (:by |S1lNv50FW) (:text |examples)
+                                  |b $ %{} :Leaf (:at 1758954689639) (:by |S1lNv50FW) (:text |0)
+                          |T $ %{} :Expr (:at 1758954677532) (:by |S1lNv50FW)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1758954679562) (:by |S1lNv50FW) (:text |eprintln)
+                              |b $ %{} :Leaf (:at 1758954789498) (:by |S1lNv50FW) (:text "|\"expect examples start with `do`:")
+                              |h $ %{} :Leaf (:at 1758954818652) (:by |S1lNv50FW) (:text |examples)
+                      |T $ %{} :Expr (:at 1758954674388) (:by |S1lNv50FW)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1758952530840) (:by |S1lNv50FW) (:text |::)
+                          |b $ %{} :Leaf (:at 1758952603130) (:by |S1lNv50FW) (:text |:exp-code)
+                          |h $ %{} :Expr (:at 1758954618694) (:by |S1lNv50FW)
+                            :data $ {}
+                              |D $ %{} :Leaf (:at 1758954621731) (:by |S1lNv50FW) (:text |rest)
+                              |P $ %{} :Leaf (:at 1758954816650) (:by |S1lNv50FW) (:text |examples)
+                          |l $ %{} :Expr (:at 1758952547580) (:by |S1lNv50FW)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1758952547580) (:by |S1lNv50FW) (:text |&list:nth)
+                              |b $ %{} :Leaf (:at 1758952547580) (:by |S1lNv50FW) (:text |xs)
+                              |h $ %{} :Leaf (:at 1758954150034) (:by |S1lNv50FW) (:text |2)
+                  |l $ %{} :Expr (:at 1758952582948) (:by |S1lNv50FW)
+                    :data $ {}
+                      |D $ %{} :Leaf (:at 1758952584742) (:by |S1lNv50FW) (:text |::)
+                      |L $ %{} :Leaf (:at 1758952600578) (:by |S1lNv50FW) (:text |:exp-code)
+                      |P $ %{} :Expr (:at 1758952604099) (:by |S1lNv50FW)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1758952604369) (:by |S1lNv50FW) (:text |[])
+                      |T $ %{} :Leaf (:at 1758952533203) (:by |S1lNv50FW) (:text |xs)
         |file->cirru $ %{} :CodeEntry (:doc |)
           :code $ %{} :Expr (:at 1504777570689) (:by nil)
             :data $ {}
@@ -40962,6 +41054,7 @@
               |r $ %{} :Expr (:at 1504777570689) (:by nil)
                 :data $ {}
                   |T $ %{} :Leaf (:at 1504777570689) (:by |root) (:text |file)
+                  |b $ %{} :Leaf (:at 1758954273710) (:by |S1lNv50FW) (:text |compact?)
               |x $ %{} :Expr (:at 1626150414434) (:by |S1lNv50FW)
                 :data $ {}
                   |T $ %{} :Leaf (:at 1693239990401) (:by |S1lNv50FW) (:text |%{})
@@ -41025,28 +41118,95 @@
                                         :data $ {}
                                           |T $ %{} :Leaf (:at 1626150471148) (:by |S1lNv50FW) (:text |[])
                                           |j $ %{} :Leaf (:at 1626150471148) (:by |S1lNv50FW) (:text |k)
-                                          |r $ %{} :Expr (:at 1692517423578) (:by |S1lNv50FW)
+                                          |r $ %{} :Expr (:at 1758952480137) (:by |S1lNv50FW)
                                             :data $ {}
-                                              |D $ %{} :Leaf (:at 1692517427912) (:by |S1lNv50FW) (:text |->)
-                                              |L $ %{} :Leaf (:at 1692517428465) (:by |S1lNv50FW) (:text |xs)
-                                              |T $ %{} :Expr (:at 1692517429889) (:by |S1lNv50FW)
+                                              |D $ %{} :Leaf (:at 1758952481267) (:by |S1lNv50FW) (:text |let)
+                                              |L $ %{} :Expr (:at 1758952481526) (:by |S1lNv50FW)
                                                 :data $ {}
-                                                  |D $ %{} :Leaf (:at 1692517433227) (:by |S1lNv50FW) (:text |update)
-                                                  |L $ %{} :Leaf (:at 1692517435881) (:by |S1lNv50FW) (:text |:code)
-                                                  |T $ %{} :Expr (:at 1692517437300) (:by |S1lNv50FW)
+                                                  |T $ %{} :Expr (:at 1758952481674) (:by |S1lNv50FW)
                                                     :data $ {}
-                                                      |D $ %{} :Leaf (:at 1692517437853) (:by |S1lNv50FW) (:text |fn)
-                                                      |L $ %{} :Expr (:at 1692517438171) (:by |S1lNv50FW)
+                                                      |T $ %{} :Leaf (:at 1758952487250) (:by |S1lNv50FW) (:text |extracted)
+                                                      |b $ %{} :Expr (:at 1758952490073) (:by |S1lNv50FW)
                                                         :data $ {}
-                                                          |T $ %{} :Leaf (:at 1692517438596) (:by |S1lNv50FW) (:text |code)
-                                                      |T $ %{} :Expr (:at 1626150476728) (:by |S1lNv50FW)
-                                                        :data $ {}
-                                                          |D $ %{} :Leaf (:at 1626150480439) (:by |S1lNv50FW) (:text |::)
-                                                          |L $ %{} :Leaf (:at 1626150482616) (:by |S1lNv50FW) (:text |'quote)
-                                                          |T $ %{} :Expr (:at 1626150471148) (:by |S1lNv50FW)
+                                                          |T $ %{} :Leaf (:at 1758952496278) (:by |S1lNv50FW) (:text |extract-examples-code)
+                                                          |b $ %{} :Expr (:at 1758952499897) (:by |S1lNv50FW)
                                                             :data $ {}
-                                                              |T $ %{} :Leaf (:at 1626150471148) (:by |S1lNv50FW) (:text |tree->cirru)
-                                                              |j $ %{} :Leaf (:at 1692517442010) (:by |S1lNv50FW) (:text |code)
+                                                              |T $ %{} :Leaf (:at 1758952499897) (:by |S1lNv50FW) (:text |tree->cirru)
+                                                              |b $ %{} :Expr (:at 1758952996682) (:by |S1lNv50FW)
+                                                                :data $ {}
+                                                                  |D $ %{} :Leaf (:at 1758952997794) (:by |S1lNv50FW) (:text |:code)
+                                                                  |T $ %{} :Leaf (:at 1758952902304) (:by |S1lNv50FW) (:text |xs)
+                                              |T $ %{} :Expr (:at 1758952608490) (:by |S1lNv50FW)
+                                                :data $ {}
+                                                  |D $ %{} :Leaf (:at 1758952610212) (:by |S1lNv50FW) (:text |tag-match)
+                                                  |L $ %{} :Leaf (:at 1758952614547) (:by |S1lNv50FW) (:text |extracted)
+                                                  |T $ %{} :Expr (:at 1758952617102) (:by |S1lNv50FW)
+                                                    :data $ {}
+                                                      |D $ %{} :Expr (:at 1758952618423) (:by |S1lNv50FW)
+                                                        :data $ {}
+                                                          |T $ %{} :Leaf (:at 1758952620154) (:by |S1lNv50FW) (:text |:exp-code)
+                                                          |b $ %{} :Leaf (:at 1758952623050) (:by |S1lNv50FW) (:text |examples)
+                                                          |h $ %{} :Leaf (:at 1758952623586) (:by |S1lNv50FW) (:text |code)
+                                                      |T $ %{} :Expr (:at 1758954306367) (:by |S1lNv50FW)
+                                                        :data $ {}
+                                                          |D $ %{} :Leaf (:at 1758954306944) (:by |S1lNv50FW) (:text |if)
+                                                          |L $ %{} :Leaf (:at 1758954306944) (:by |S1lNv50FW) (:text |compact?)
+                                                          |T $ %{} :Expr (:at 1692517423578) (:by |S1lNv50FW)
+                                                            :data $ {}
+                                                              |D $ %{} :Leaf (:at 1758954161301) (:by |S1lNv50FW) (:text |%{})
+                                                              |J $ %{} :Leaf (:at 1758954310491) (:by |S1lNv50FW) (:text |schema/CodeEntryCompact)
+                                                              |P $ %{} :Expr (:at 1758954176206) (:by |S1lNv50FW)
+                                                                :data $ {}
+                                                                  |T $ %{} :Leaf (:at 1758954176887) (:by |S1lNv50FW) (:text |:doc)
+                                                                  |b $ %{} :Expr (:at 1758954177731) (:by |S1lNv50FW)
+                                                                    :data $ {}
+                                                                      |T $ %{} :Leaf (:at 1758954178335) (:by |S1lNv50FW) (:text |:doc)
+                                                                      |b $ %{} :Leaf (:at 1758954182295) (:by |S1lNv50FW) (:text |xs)
+                                                              |T $ %{} :Expr (:at 1692517429889) (:by |S1lNv50FW)
+                                                                :data $ {}
+                                                                  |L $ %{} :Leaf (:at 1692517435881) (:by |S1lNv50FW) (:text |:code)
+                                                                  |T $ %{} :Expr (:at 1758953709085) (:by |S1lNv50FW)
+                                                                    :data $ {}
+                                                                      |T $ %{} :Leaf (:at 1758953709085) (:by |S1lNv50FW) (:text |::)
+                                                                      |b $ %{} :Leaf (:at 1758953709085) (:by |S1lNv50FW) (:text |'quote)
+                                                                      |h $ %{} :Leaf (:at 1758953709085) (:by |S1lNv50FW) (:text |code)
+                                                              |b $ %{} :Expr (:at 1758952637613) (:by |S1lNv50FW)
+                                                                :data $ {}
+                                                                  |b $ %{} :Leaf (:at 1758952640721) (:by |S1lNv50FW) (:text |:examples)
+                                                                  |h $ %{} :Expr (:at 1758952647507) (:by |S1lNv50FW)
+                                                                    :data $ {}
+                                                                      |T $ %{} :Leaf (:at 1758952647996) (:by |S1lNv50FW) (:text |map)
+                                                                      |b $ %{} :Leaf (:at 1758952651596) (:by |S1lNv50FW) (:text |examples)
+                                                                      |h $ %{} :Expr (:at 1758952652584) (:by |S1lNv50FW)
+                                                                        :data $ {}
+                                                                          |T $ %{} :Leaf (:at 1758952652866) (:by |S1lNv50FW) (:text |fn)
+                                                                          |b $ %{} :Expr (:at 1758952653782) (:by |S1lNv50FW)
+                                                                            :data $ {}
+                                                                              |T $ %{} :Leaf (:at 1758952655146) (:by |S1lNv50FW) (:text |e)
+                                                                          |h $ %{} :Expr (:at 1758952656033) (:by |S1lNv50FW)
+                                                                            :data $ {}
+                                                                              |T $ %{} :Leaf (:at 1758952660579) (:by |S1lNv50FW) (:text |::)
+                                                                              |b $ %{} :Leaf (:at 1758952662813) (:by |S1lNv50FW) (:text |'quote)
+                                                                              |h $ %{} :Leaf (:at 1758952665547) (:by |S1lNv50FW) (:text |e)
+                                                          |b $ %{} :Expr (:at 1692517423578) (:by |S1lNv50FW)
+                                                            :data $ {}
+                                                              |D $ %{} :Leaf (:at 1758954161301) (:by |S1lNv50FW) (:text |%{})
+                                                              |J $ %{} :Leaf (:at 1758954316193) (:by |S1lNv50FW) (:text |schema/CodeEntry)
+                                                              |P $ %{} :Expr (:at 1758954176206) (:by |S1lNv50FW)
+                                                                :data $ {}
+                                                                  |T $ %{} :Leaf (:at 1758954176887) (:by |S1lNv50FW) (:text |:doc)
+                                                                  |b $ %{} :Expr (:at 1758954177731) (:by |S1lNv50FW)
+                                                                    :data $ {}
+                                                                      |T $ %{} :Leaf (:at 1758954178335) (:by |S1lNv50FW) (:text |:doc)
+                                                                      |b $ %{} :Leaf (:at 1758954182295) (:by |S1lNv50FW) (:text |xs)
+                                                              |T $ %{} :Expr (:at 1692517429889) (:by |S1lNv50FW)
+                                                                :data $ {}
+                                                                  |L $ %{} :Leaf (:at 1692517435881) (:by |S1lNv50FW) (:text |:code)
+                                                                  |T $ %{} :Expr (:at 1758953709085) (:by |S1lNv50FW)
+                                                                    :data $ {}
+                                                                      |T $ %{} :Leaf (:at 1758953709085) (:by |S1lNv50FW) (:text |::)
+                                                                      |b $ %{} :Leaf (:at 1758953709085) (:by |S1lNv50FW) (:text |'quote)
+                                                                      |h $ %{} :Leaf (:at 1758953709085) (:by |S1lNv50FW) (:text |code)
                                       |b $ %{} :Leaf (:at 1693239226259) (:by |S1lNv50FW) (:text |nil)
         |file-compact-to-calcit $ %{} :CodeEntry (:doc |)
           :code $ %{} :Expr (:at 1650734756741) (:by |S1lNv50FW)
@@ -42092,6 +42252,7 @@
                                                     :data $ {}
                                                       |T $ %{} :Leaf (:at 1625684405046) (:by |S1lNv50FW) (:text |file->cirru)
                                                       |j $ %{} :Leaf (:at 1625684407401) (:by |S1lNv50FW) (:text |v)
+                                                      |n $ %{} :Leaf (:at 1758954363297) (:by |S1lNv50FW) (:text |true)
                       |j $ %{} :Expr (:at 1596336845843) (:by |S1lNv50FW)
                         :data $ {}
                           |T $ %{} :Leaf (:at 1596336850628) (:by |S1lNv50FW) (:text |inc-data)
@@ -42133,6 +42294,7 @@
                                                               |T $ %{} :Leaf (:at 1596343323593) (:by |S1lNv50FW) (:text |get)
                                                               |j $ %{} :Leaf (:at 1596343321832) (:by |S1lNv50FW) (:text |new-files)
                                                               |r $ %{} :Leaf (:at 1596343314610) (:by |S1lNv50FW) (:text |ns-text)
+                                                          |n $ %{} :Leaf (:at 1758954369712) (:by |S1lNv50FW) (:text |true)
                                           |r $ %{} :Expr (:at 1596336944822) (:by |S1lNv50FW)
                                             :data $ {}
                                               |T $ %{} :Leaf (:at 1625725700083) (:by |S1lNv50FW) (:text |pairs-map)
@@ -42316,22 +42478,45 @@
                                                                                     :data $ {}
                                                                                       |T $ %{} :Leaf (:at 1596343603121) (:by |S1lNv50FW) (:text |[])
                                                                                       |j $ %{} :Leaf (:at 1596343603580) (:by |S1lNv50FW) (:text |x)
-                                                                                      |r $ %{} :Expr (:at 1625831098256) (:by |S1lNv50FW)
+                                                                                      |r $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
                                                                                         :data $ {}
-                                                                                          |5 $ %{} :Leaf (:at 1625831099981) (:by |S1lNv50FW) (:text |::)
-                                                                                          |D $ %{} :Leaf (:at 1625831098904) (:by |S1lNv50FW) (:text |'quote)
-                                                                                          |T $ %{} :Expr (:at 1596343624138) (:by |S1lNv50FW)
+                                                                                          |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |let)
+                                                                                          |b $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
                                                                                             :data $ {}
-                                                                                              |D $ %{} :Leaf (:at 1596343624921) (:by |S1lNv50FW) (:text |tree->cirru)
-                                                                                              |T $ %{} :Expr (:at 1596343605015) (:by |S1lNv50FW)
+                                                                                              |T $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
                                                                                                 :data $ {}
-                                                                                                  |T $ %{} :Leaf (:at 1692519119364) (:by |S1lNv50FW) (:text |get-in)
-                                                                                                  |j $ %{} :Leaf (:at 1596343612564) (:by |S1lNv50FW) (:text |new-defs)
-                                                                                                  |r $ %{} :Expr (:at 1692519120833) (:by |S1lNv50FW)
+                                                                                                  |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |extracted)
+                                                                                                  |b $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
                                                                                                     :data $ {}
-                                                                                                      |D $ %{} :Leaf (:at 1692519121388) (:by |S1lNv50FW) (:text |[])
-                                                                                                      |T $ %{} :Leaf (:at 1596343613261) (:by |S1lNv50FW) (:text |x)
-                                                                                                      |b $ %{} :Leaf (:at 1692519122783) (:by |S1lNv50FW) (:text |:code)
+                                                                                                      |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |extract-examples-code)
+                                                                                                      |b $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                                        :data $ {}
+                                                                                                          |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |tree->cirru)
+                                                                                                          |b $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                                            :data $ {}
+                                                                                                              |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |get-in)
+                                                                                                              |b $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |new-defs)
+                                                                                                              |h $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                                                :data $ {}
+                                                                                                                  |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |[])
+                                                                                                                  |b $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |x)
+                                                                                                                  |h $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |:code)
+                                                                                          |h $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                            :data $ {}
+                                                                                              |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |tag-match)
+                                                                                              |b $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |extracted)
+                                                                                              |h $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                                :data $ {}
+                                                                                                  |T $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                                    :data $ {}
+                                                                                                      |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |:exp-code)
+                                                                                                      |b $ %{} :Leaf (:at 1758954903349) (:by |S1lNv50FW) (:text |_e)
+                                                                                                      |h $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |code)
+                                                                                                  |b $ %{} :Expr (:at 1758952730251) (:by |S1lNv50FW)
+                                                                                                    :data $ {}
+                                                                                                      |T $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |::)
+                                                                                                      |b $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |'quote)
+                                                                                                      |h $ %{} :Leaf (:at 1758952730251) (:by |S1lNv50FW) (:text |code)
                                                                           |x $ %{} :Expr (:at 1596345055037) (:by |S1lNv50FW)
                                                                             :data $ {}
                                                                               |T $ %{} :Leaf (:at 1596345055660) (:by |S1lNv50FW) (:text |hide-empty-fields)
@@ -42355,22 +42540,45 @@
                                                                                     :data $ {}
                                                                                       |T $ %{} :Leaf (:at 1596343603121) (:by |S1lNv50FW) (:text |[])
                                                                                       |j $ %{} :Leaf (:at 1596343603580) (:by |S1lNv50FW) (:text |x)
-                                                                                      |r $ %{} :Expr (:at 1625831101623) (:by |S1lNv50FW)
+                                                                                      |r $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
                                                                                         :data $ {}
-                                                                                          |D $ %{} :Leaf (:at 1625831103317) (:by |S1lNv50FW) (:text |::)
-                                                                                          |L $ %{} :Leaf (:at 1625831103726) (:by |S1lNv50FW) (:text |'quote)
-                                                                                          |T $ %{} :Expr (:at 1596343624138) (:by |S1lNv50FW)
+                                                                                          |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |let)
+                                                                                          |b $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
                                                                                             :data $ {}
-                                                                                              |D $ %{} :Leaf (:at 1596343624921) (:by |S1lNv50FW) (:text |tree->cirru)
-                                                                                              |T $ %{} :Expr (:at 1596343605015) (:by |S1lNv50FW)
+                                                                                              |T $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
                                                                                                 :data $ {}
-                                                                                                  |T $ %{} :Leaf (:at 1692519127599) (:by |S1lNv50FW) (:text |get-in)
-                                                                                                  |j $ %{} :Leaf (:at 1596343612564) (:by |S1lNv50FW) (:text |new-defs)
-                                                                                                  |r $ %{} :Expr (:at 1692519129363) (:by |S1lNv50FW)
+                                                                                                  |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |extracted)
+                                                                                                  |b $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
                                                                                                     :data $ {}
-                                                                                                      |D $ %{} :Leaf (:at 1692519129942) (:by |S1lNv50FW) (:text |[])
-                                                                                                      |T $ %{} :Leaf (:at 1596343613261) (:by |S1lNv50FW) (:text |x)
-                                                                                                      |b $ %{} :Leaf (:at 1692519131342) (:by |S1lNv50FW) (:text |:code)
+                                                                                                      |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |extract-examples-code)
+                                                                                                      |b $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                                        :data $ {}
+                                                                                                          |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |tree->cirru)
+                                                                                                          |b $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                                            :data $ {}
+                                                                                                              |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |get-in)
+                                                                                                              |b $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |new-defs)
+                                                                                                              |h $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                                                :data $ {}
+                                                                                                                  |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |[])
+                                                                                                                  |b $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |x)
+                                                                                                                  |h $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |:code)
+                                                                                          |h $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                            :data $ {}
+                                                                                              |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |tag-match)
+                                                                                              |b $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |extracted)
+                                                                                              |h $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                                :data $ {}
+                                                                                                  |T $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                                    :data $ {}
+                                                                                                      |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |:exp-code)
+                                                                                                      |b $ %{} :Leaf (:at 1758954905477) (:by |S1lNv50FW) (:text |_e)
+                                                                                                      |h $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |code)
+                                                                                                  |b $ %{} :Expr (:at 1758952751620) (:by |S1lNv50FW)
+                                                                                                    :data $ {}
+                                                                                                      |T $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |::)
+                                                                                                      |b $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |'quote)
+                                                                                                      |h $ %{} :Leaf (:at 1758952751620) (:by |S1lNv50FW) (:text |code)
                                                                           |v $ %{} :Expr (:at 1596345062653) (:by |S1lNv50FW)
                                                                             :data $ {}
                                                                               |T $ %{} :Leaf (:at 1596345060672) (:by |S1lNv50FW) (:text |hide-empty-fields)
@@ -42869,6 +43077,7 @@
                         |w $ %{} :Leaf (:at 1596300275578) (:by |S1lNv50FW) (:text |tree->cirru)
                         |x $ %{} :Leaf (:at 1582040620391) (:by |S1lNv50FW) (:text |now!)
                         |y $ %{} :Leaf (:at 1596345043452) (:by |S1lNv50FW) (:text |hide-empty-fields)
+                        |z $ %{} :Leaf (:at 1758952879938) (:by |S1lNv50FW) (:text |extract-examples-code)
                 |yT $ %{} :Expr (:at 1505982441106) (:by |root)
                   :data $ {}
                     |j $ %{} :Leaf (:at 1546180055977) (:by |root) (:text "|\"chalk")

--- a/compact.cirru
+++ b/compact.cirru
@@ -1,6 +1,6 @@
 
 {} (:package |app)
-  :configs $ {} (:init-fn |app.server/main!) (:reload-fn |app.server/reload!) (:version |0.9.9)
+  :configs $ {} (:init-fn |app.server/main!) (:reload-fn |app.server/reload!) (:version |0.9.10)
     :modules $ [] |lilac/ |memof/ |recollect/ |cumulo-util.calcit/ |ws-edn.calcit/ |bisection-key/ |respo-markdown.calcit/
   :entries $ {}
     :client $ {} (:init-fn |app.client/main!) (:reload-fn |app.client/reload!)
@@ -1086,7 +1086,7 @@
               let
                   cursor $ :cursor states
                   state $ or (:data states)
-                    format-cirru-edn $ file->cirru file
+                    format-cirru-edn $ file->cirru file false
                 comp-modal
                   fn (d!) (d! :writer/draft-ns nil)
                   div
@@ -3507,6 +3507,9 @@
         |CodeEntry $ %{} :CodeEntry (:doc |)
           :code $ quote
             def CodeEntry $ new-record :CodeEntry :doc :code
+        |CodeEntryCompact $ %{} :CodeEntry (:doc "|another record for CodeEntry which only used in writing compact file")
+          :code $ quote
+            def CodeEntryCompact $ new-record :CodeEntry :doc :code :examples
         |FileEntry $ %{} :CodeEntry (:doc |)
           :code $ quote
             def FileEntry $ new-record :FileEntry :ns :defs
@@ -5938,9 +5941,22 @@
         |expr? $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn expr? (x) (&record:matches? schema/CirruExpr x)
+        |extract-examples-code $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn extract-examples-code (xs)
+              if
+                &= "\"with-examples" $ &list:nth xs 0
+                let
+                    examples $ &list:nth xs 1
+                  assert= 3 $ &list:count xs
+                  if
+                    not= "\"do" $ &list:nth examples 0
+                    eprintln "\"expect examples start with `do`:" examples
+                  :: :exp-code (rest examples) (&list:nth xs 2)
+                :: :exp-code ([]) xs
         |file->cirru $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn file->cirru (file)
+            defn file->cirru (file compact?)
               %{} schema/FileEntry
                 :ns $ -> (:ns file)
                   update :code $ fn (code)
@@ -5948,9 +5964,20 @@
                 :defs $ -> (:defs file)
                   map-kv $ fn (k xs)
                     if (some? xs)
-                      [] k $ -> xs
-                        update :code $ fn (code)
-                          :: 'quote $ tree->cirru code
+                      [] k $ let
+                          extracted $ extract-examples-code
+                            tree->cirru $ :code xs
+                        tag-match extracted $ 
+                          :exp-code examples code
+                          if compact?
+                            %{} schema/CodeEntryCompact
+                              :doc $ :doc xs
+                              :code $ :: 'quote code
+                              :examples $ map examples
+                                fn (e) (:: 'quote e)
+                            %{} schema/CodeEntry
+                              :doc $ :doc xs
+                              :code $ :: 'quote code
                       , nil
         |file-compact-to-calcit $ %{} :CodeEntry (:doc |)
           :code $ quote
@@ -6116,12 +6143,12 @@
                     :entries entries
                     :files $ -> new-files
                       map-kv $ fn (k v)
-                        [] k $ file->cirru v
+                        [] k $ file->cirru v true
                   inc-data $ hide-empty-fields
                     {} (:removed removed-names)
                       :added $ -> added-names
                         map $ fn (ns-text)
-                          [] ns-text $ file->cirru (get new-files ns-text)
+                          [] ns-text $ file->cirru (get new-files ns-text) true
                         pairs-map
                       :changed $ -> changed-names
                         map $ fn (ns-text)
@@ -6146,13 +6173,21 @@
                               :removed-defs removed-defs
                               :added-defs $ -> added-defs
                                 map $ fn (x)
-                                  [] x $ :: 'quote
-                                    tree->cirru $ get-in new-defs ([] x :code)
+                                  [] x $ let
+                                      extracted $ extract-examples-code
+                                        tree->cirru $ get-in new-defs ([] x :code)
+                                    tag-match extracted $ 
+                                      :exp-code _e code
+                                      :: 'quote code
                                 hide-empty-fields
                               :changed-defs $ -> changed-defs
                                 map $ fn (x)
-                                  [] x $ :: 'quote
-                                    tree->cirru $ get-in new-defs ([] x :code)
+                                  [] x $ let
+                                      extracted $ extract-examples-code
+                                        tree->cirru $ get-in new-defs ([] x :code)
+                                    tag-match extracted $ 
+                                      :exp-code _e code
+                                      :: 'quote code
                                 hide-empty-fields
                         pairs-map
                 fs/writeFile "\"compact.cirru" (format-cirru-edn compact-data)
@@ -6228,7 +6263,7 @@
       :ns $ %{} :CodeEntry (:doc |)
         :code $ quote
           ns app.util.compile $ :require
-            app.util :refer $ file->cirru db->string tree->cirru now! hide-empty-fields
+            app.util :refer $ file->cirru db->string tree->cirru now! hide-empty-fields extract-examples-code
             "\"chalk" :default chalk
             "\"path" :as path
             "\"fs" :as fs

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,12 +1,12 @@
 
-{} (:calcit-version |0.9.16)
+{} (:calcit-version |0.9.19)
   :dependencies $ {} (|Cumulo/cumulo-util.calcit |main)
     |Respo/alerts.calcit |0.10.2
     |Respo/respo-feather.calcit |main
-    |Respo/respo-markdown.calcit |0.4.9
+    |Respo/respo-markdown.calcit |0.4.11
     |Respo/respo-message.calcit |main
     |Respo/respo-ui.calcit |0.6.3
-    |Respo/respo.calcit |0.16.16
+    |Respo/respo.calcit |0.16.18
     |calcit-lang/bisection-key |0.0.16
     |calcit-lang/gen-code |0.0.5
     |calcit-lang/lilac |main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/editor",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Structural Editor for Calcit Language",
   "bin": {
     "ct": "server.mjs"
@@ -21,19 +21,19 @@
   "devDependencies": {
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
-    "copy-text-to-clipboard": "^3.2.0",
+    "copy-text-to-clipboard": "^3.2.2",
     "feather-icons": "^4.29.2",
     "url-parse": "^1.5.10",
-    "vite": "^7.0.6"
+    "vite": "^7.1.7"
   },
   "dependencies": {
-    "@calcit/procs": "^0.9.16",
-    "@google/genai": "^1.11.0",
-    "chalk": "^5.4.1",
-    "dayjs": "^1.11.13",
+    "@calcit/procs": "^0.9.19",
+    "@google/genai": "^1.21.0",
+    "chalk": "^5.6.2",
+    "dayjs": "^1.11.18",
     "gaze": "^1.1.3",
     "latest-version": "^9.0.0",
-    "nanoid": "^5.1.5",
+    "nanoid": "^5.1.6",
     "ws": "^8.18.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.9.16":
-  version "0.9.16"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.9.16.tgz#58eb043cec42f12fd714e21dfcf0e1daba0cd8b3"
-  integrity sha512-14q5V4fnmAVhMzuKdJa4f5UB8OGxKmES0vxcOrCul8FRkhZ638rwygRTFY08oGwkXJ93ujeDDkQ6dESeubO0yA==
+"@calcit/procs@^0.9.19":
+  version "0.9.19"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.9.19.tgz#a5994f09d4ba579d491358f3e103aa5806fdb99d"
+  integrity sha512-JRMDQKPAKhPKHpPXx47etPDFaTOu4XNQRr6pRrmPdZyxnt5GXBpZ1koOmA6+kXs6ad4+tNySFOwdg1qsCubvUw==
   dependencies:
-    "@calcit/ternary-tree" "0.0.24"
+    "@calcit/ternary-tree" "0.0.25"
     "@cirru/parser.ts" "^0.0.6"
     "@cirru/writer.ts" "^0.1.5"
 
-"@calcit/ternary-tree@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@calcit/ternary-tree/-/ternary-tree-0.0.24.tgz#9b58cf9f76c08c3995b98b59c71b85e1da32385c"
-  integrity sha512-IGs+VNYIrIF2bI3/cnQe2lFmZYaJe3+A0LArDloGbNaEzUTRoyba37FTZ8K9C+XRpUAO9K0q61sKY2vb4teWAA==
+"@calcit/ternary-tree@0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@calcit/ternary-tree/-/ternary-tree-0.0.25.tgz#d467cbd9a7f89ff1fdb590e5d1551aefa6a03492"
+  integrity sha512-BxAAq6v7dZJDYSMX5kBVQ/eSYX7czjOS1cHM25js4yD+Q2I61RxxhD7iBaGlfNJvmgPmvYJQA5nxNmN2TEXq7A==
 
 "@cirru/parser.ts@^0.0.6":
   version "0.0.6"
@@ -26,140 +26,140 @@
   resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.5.tgz#890d96cd4a69609f1682932dad5d2d467abb327e"
   integrity sha512-QQVFJAOIdUtVJZwT23THZOzumSDXCLMQ0yFz5DzIGlWGXPNBuB7BwUvGtRuiQrzM2XV7ALOWmNsVC7vEOjObQQ==
 
-"@esbuild/aix-ppc64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz#a1414903bb38027382f85f03dda6065056757727"
-  integrity sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==
+"@esbuild/aix-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
+  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
 
-"@esbuild/android-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz#c859994089e9767224269884061f89dae6fb51c6"
-  integrity sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==
+"@esbuild/android-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
+  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
 
-"@esbuild/android-arm@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.8.tgz#96a8f2ca91c6cd29ea90b1af79d83761c8ba0059"
-  integrity sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==
+"@esbuild/android-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
+  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
 
-"@esbuild/android-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.8.tgz#a3a626c4fec4a024a9fa8c7679c39996e92916f0"
-  integrity sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==
+"@esbuild/android-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
+  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
 
-"@esbuild/darwin-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz#a5e1252ca2983d566af1c0ea39aded65736fc66d"
-  integrity sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==
+"@esbuild/darwin-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz#6af6bb1d05887dac515de1b162b59dc71212ed76"
+  integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
 
-"@esbuild/darwin-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz#5271b0df2bb12ce8df886704bfdd1c7cc01385d2"
-  integrity sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==
+"@esbuild/darwin-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
+  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
 
-"@esbuild/freebsd-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz#d0a0e7fdf19733b8bb1566b81df1aa0bb7e46ada"
-  integrity sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==
+"@esbuild/freebsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
+  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
 
-"@esbuild/freebsd-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz#2de8b2e0899d08f1cb1ef3128e159616e7e85343"
-  integrity sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==
+"@esbuild/freebsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
+  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
 
-"@esbuild/linux-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz#a4209efadc0c2975716458484a4e90c237c48ae9"
-  integrity sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==
+"@esbuild/linux-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
+  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
 
-"@esbuild/linux-arm@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz#ccd9e291c24cd8d9142d819d463e2e7200d25b19"
-  integrity sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==
+"@esbuild/linux-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
+  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
 
-"@esbuild/linux-ia32@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz#006ad1536d0c2b28fb3a1cf0b53bcb85aaf92c4d"
-  integrity sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==
+"@esbuild/linux-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
+  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
 
-"@esbuild/linux-loong64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz#127b3fbfb2c2e08b1397e985932f718f09a8f5c4"
-  integrity sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==
+"@esbuild/linux-loong64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
+  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
 
-"@esbuild/linux-mips64el@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz#837d1449517791e3fa7d82675a2d06d9f56cb340"
-  integrity sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==
+"@esbuild/linux-mips64el@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
+  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
 
-"@esbuild/linux-ppc64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz#aa2e3bd93ab8df084212f1895ca4b03c42d9e0fe"
-  integrity sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==
+"@esbuild/linux-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
+  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
 
-"@esbuild/linux-riscv64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz#a340620e31093fef72767dd28ab04214b3442083"
-  integrity sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==
+"@esbuild/linux-riscv64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
+  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
 
-"@esbuild/linux-s390x@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz#ddfed266c8c13f5efb3105a0cd47f6dcd0e79e71"
-  integrity sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==
+"@esbuild/linux-s390x@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
+  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
 
-"@esbuild/linux-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz#9a4f78c75c051e8c060183ebb39a269ba936a2ac"
-  integrity sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==
+"@esbuild/linux-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
+  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
 
-"@esbuild/netbsd-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz#902c80e1d678047926387230bc037e63e00697d0"
-  integrity sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==
+"@esbuild/netbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
+  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
 
-"@esbuild/netbsd-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz#2d9eb4692add2681ff05a14ce99de54fbed7079c"
-  integrity sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==
+"@esbuild/netbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
+  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
 
-"@esbuild/openbsd-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz#89c3b998c6de739db38ab7fb71a8a76b3fa84a45"
-  integrity sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==
+"@esbuild/openbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
+  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
 
-"@esbuild/openbsd-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz#2f01615cf472b0e48c077045cfd96b5c149365cc"
-  integrity sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==
+"@esbuild/openbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
+  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
 
-"@esbuild/openharmony-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz#a201f720cd2c3ebf9a6033fcc3feb069a54b509a"
-  integrity sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==
+"@esbuild/openharmony-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
+  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
 
-"@esbuild/sunos-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz#07046c977985a3334667f19e6ab3a01a80862afb"
-  integrity sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==
+"@esbuild/sunos-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
+  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
 
-"@esbuild/win32-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz#4a5470caf0d16127c05d4833d4934213c69392d1"
-  integrity sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==
+"@esbuild/win32-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
+  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
 
-"@esbuild/win32-ia32@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz#3de3e8470b7b328d99dbc3e9ec1eace207e5bbc4"
-  integrity sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==
+"@esbuild/win32-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
+  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
 
-"@esbuild/win32-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz#610d7ea539d2fcdbe39237b5cc175eb2c4451f9c"
-  integrity sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==
+"@esbuild/win32-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
+  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
 
-"@google/genai@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-1.11.0.tgz#05468f09c85abaabd9afdc3ecea92882765ef5e9"
-  integrity sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==
+"@google/genai@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-1.21.0.tgz#3385514882bcf6cf5cb1d3ec218422a7b2fa56f1"
+  integrity sha512-k47DECR8BF9z7IJxQd3reKuH2eUnOH5NlJWSe+CKM6nbXx+wH3hmtWQxUQR9M8gzWW1EvFuRVgjQssEIreNZsw==
   dependencies:
     google-auth-library "^9.14.2"
     ws "^8.18.0"
@@ -185,105 +185,115 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@rollup/rollup-android-arm-eabi@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.1.tgz#c659481d5b15054d4636b3dd0c2f50ab3083d839"
-  integrity sha512-oENme6QxtLCqjChRUUo3S6X8hjCXnWmJWnedD7VbGML5GUtaOtAyx+fEEXnBXVf0CBZApMQU0Idwi0FmyxzQhw==
+"@rollup/rollup-android-arm-eabi@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz#3a43e904367cd6147c5a8de9df4ff7ffa48634ec"
+  integrity sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==
 
-"@rollup/rollup-android-arm64@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.1.tgz#7e05c3c0bf6a79ee6b40ab5e778679742f06815d"
-  integrity sha512-OikvNT3qYTl9+4qQ9Bpn6+XHM+ogtFadRLuT2EXiFQMiNkXFLQfNVppi5o28wvYdHL2s3fM0D/MZJ8UkNFZWsw==
+"@rollup/rollup-android-arm64@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz#7af548eefb4def2fb678a207ff0236a045678be7"
+  integrity sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==
 
-"@rollup/rollup-darwin-arm64@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.1.tgz#b190fbd0274fbbd4d257ff0b3d68f0885c454e0d"
-  integrity sha512-EFYNNGij2WllnzljQDQnlFTXzSJw87cpAs4TVBAWLdkvic5Uh5tISrIL6NRcxoh/b2EFBG/TK8hgRrGx94zD4A==
+"@rollup/rollup-darwin-arm64@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz#13a9b8d3e31e7425b71d0caf13527ead19baf27a"
+  integrity sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==
 
-"@rollup/rollup-darwin-x64@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.1.tgz#a4df7fa06ac318b66a6aa66d6f1e0a58fef58cd3"
-  integrity sha512-ZaNH06O1KeTug9WI2+GRBE5Ujt9kZw4a1+OIwnBHal92I8PxSsl5KpsrPvthRynkhMck4XPdvY0z26Cym/b7oA==
+"@rollup/rollup-darwin-x64@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz#c794e406914ff9e3ffbfe994080590135e70ad9a"
+  integrity sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==
 
-"@rollup/rollup-freebsd-arm64@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.1.tgz#6634478a78a0c17dcf55adb621fa66faa58a017b"
-  integrity sha512-n4SLVebZP8uUlJ2r04+g2U/xFeiQlw09Me5UFqny8HGbARl503LNH5CqFTb5U5jNxTouhRjai6qPT0CR5c/Iig==
+"@rollup/rollup-freebsd-arm64@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz#63fa5783edd02a7aae141fc718e1f26882736c2b"
+  integrity sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==
 
-"@rollup/rollup-freebsd-x64@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.1.tgz#db42c46c0263b2562e2ba5c2e00e318646f2b24c"
-  integrity sha512-8vu9c02F16heTqpvo3yeiu7Vi1REDEC/yES/dIfq3tSXe6mLndiwvYr3AAvd1tMNUqE9yeGYa5w7PRbI5QUV+w==
+"@rollup/rollup-freebsd-x64@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz#5c22816795cebb4f64d6440dd52951e5948ed1e3"
+  integrity sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.1.tgz#88ca443ad42c70555978b000c6d1dd925fb3203b"
-  integrity sha512-K4ncpWl7sQuyp6rWiGUvb6Q18ba8mzM0rjWJ5JgYKlIXAau1db7hZnR0ldJvqKWWJDxqzSLwGUhA4jp+KqgDtQ==
+"@rollup/rollup-linux-arm-gnueabihf@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz#e65c6cf40153e06cfc7d2e15bb9ce8333a033649"
+  integrity sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==
 
-"@rollup/rollup-linux-arm-musleabihf@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.1.tgz#36106fe103d32c2a97583ebadcfb28dc63988bda"
-  integrity sha512-YykPnXsjUjmXE6j6k2QBBGAn1YsJUix7pYaPLK3RVE0bQL2jfdbfykPxfF8AgBlqtYbfEnYHmLXNa6QETjdOjQ==
+"@rollup/rollup-linux-arm-musleabihf@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz#d17ffee4a8b73d9dac55590748f8ec1d88c9398d"
+  integrity sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==
 
-"@rollup/rollup-linux-arm64-gnu@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.1.tgz#00c28bc9210dcfbb5e7fa8e52fd827fb570afe26"
-  integrity sha512-kKvqBGbZ8i9pCGW3a1FH3HNIVg49dXXTsChGFsHGXQaVJPLA4f/O+XmTxfklhccxdF5FefUn2hvkoGJH0ScWOA==
+"@rollup/rollup-linux-arm64-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz#b359b24b1c1f40f5920d2fd827fde1407608a941"
+  integrity sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==
 
-"@rollup/rollup-linux-arm64-musl@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.1.tgz#45a13486b5523235eb87b349e7ca5a0bb85a5b0e"
-  integrity sha512-zzX5nTw1N1plmqC9RGC9vZHFuiM7ZP7oSWQGqpbmfjK7p947D518cVK1/MQudsBdcD84t6k70WNczJOct6+hdg==
+"@rollup/rollup-linux-arm64-musl@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz#d8260f24d292525b03e5c257dee8e46de0df61bc"
+  integrity sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.1.tgz#b8edd99f072cd652acbbddc1c539b1ac4254381d"
-  integrity sha512-O8CwgSBo6ewPpktFfSDgB6SJN9XDcPSvuwxfejiddbIC/hn9Tg6Ai0f0eYDf3XvB/+PIWzOQL+7+TZoB8p9Yuw==
+"@rollup/rollup-linux-loong64-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz#da159bad4467c41868a0803d4009839aac2f38d3"
+  integrity sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==
 
-"@rollup/rollup-linux-ppc64-gnu@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.1.tgz#0ec72a4f8b7a86b13c0f6b7666ed1d3b6e8e67cc"
-  integrity sha512-JnCfFVEKeq6G3h3z8e60kAp8Rd7QVnWCtPm7cxx+5OtP80g/3nmPtfdCXbVl063e3KsRnGSKDHUQMydmzc/wBA==
+"@rollup/rollup-linux-ppc64-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz#f0b10d49210bef2eed9ae7a0ec9ef3e3bf1beffd"
+  integrity sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==
 
-"@rollup/rollup-linux-riscv64-gnu@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.1.tgz#99f06928528fb58addd12e50827e1a0269c1cca8"
-  integrity sha512-dVxuDqS237eQXkbYzQQfdf/njgeNw6LZuVyEdUaWwRpKHhsLI+y4H/NJV8xJGU19vnOJCVwaBFgr936FHOnJsQ==
+"@rollup/rollup-linux-riscv64-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz#f3d023dc14669780de638c662b3ecf6431253bb8"
+  integrity sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==
 
-"@rollup/rollup-linux-riscv64-musl@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.1.tgz#3c14aba63b4170fe3d9d0b6ad98361366170590e"
-  integrity sha512-CvvgNl2hrZrTR9jXK1ye0Go0HQRT6ohQdDfWR47/KFKiLd5oN5T14jRdUVGF4tnsN8y9oSfMOqH6RuHh+ck8+w==
+"@rollup/rollup-linux-riscv64-musl@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz#1c451e83ae32ad926c3af90a0a64073d432aa179"
+  integrity sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==
 
-"@rollup/rollup-linux-s390x-gnu@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.1.tgz#34c647a823dcdca0f749a2bdcbde4fb131f37a4c"
-  integrity sha512-x7ANt2VOg2565oGHJ6rIuuAon+A8sfe1IeUx25IKqi49OjSr/K3awoNqr9gCwGEJo9OuXlOn+H2p1VJKx1psxA==
+"@rollup/rollup-linux-s390x-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz#ca91af9d54132db20f06ffdf6b81720aeb434e7b"
+  integrity sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==
 
-"@rollup/rollup-linux-x64-gnu@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.1.tgz#3991010418c005e8791c415e7c2072b247157710"
-  integrity sha512-9OADZYryz/7E8/qt0vnaHQgmia2Y0wrjSSn1V/uL+zw/i7NUhxbX4cHXdEQ7dnJgzYDS81d8+tf6nbIdRFZQoQ==
+"@rollup/rollup-linux-x64-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz#074807dca3a15542b5e224ef6138f000a1015193"
+  integrity sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==
 
-"@rollup/rollup-linux-x64-musl@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.1.tgz#f3943e5f284f40ffbcf4a14da9ee2e43d303b462"
-  integrity sha512-NuvSCbXEKY+NGWHyivzbjSVJi68Xfq1VnIvGmsuXs6TCtveeoDRKutI5vf2ntmNnVq64Q4zInet0UDQ+yMB6tA==
+"@rollup/rollup-linux-x64-musl@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz#b786fd7a6b0a1146be56d952626170f3784594e9"
+  integrity sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==
 
-"@rollup/rollup-win32-arm64-msvc@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.1.tgz#45b5a1d3f0af63f85044913c371d7b0519c913ad"
-  integrity sha512-mWz+6FSRb82xuUMMV1X3NGiaPFqbLN9aIueHleTZCc46cJvwTlvIh7reQLk4p97dv0nddyewBhwzryBHH7wtPw==
+"@rollup/rollup-openharmony-arm64@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz#4bd9469e14c178186c5c594a7d418aaeb031df81"
+  integrity sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==
 
-"@rollup/rollup-win32-ia32-msvc@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.1.tgz#900ef7211d2929e9809f3a044c4e2fd3aa685a0c"
-  integrity sha512-7Thzy9TMXDw9AU4f4vsLNBxh7/VOKuXi73VH3d/kHGr0tZ3x/ewgL9uC7ojUKmH1/zvmZe2tLapYcZllk3SO8Q==
+"@rollup/rollup-win32-arm64-msvc@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz#3e82d9cfcbcf268dbb861c49f631b17a68ed0411"
+  integrity sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==
 
-"@rollup/rollup-win32-x64-msvc@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.1.tgz#932d8696dfef673bee1a1e291a5531d25a6903be"
-  integrity sha512-7GVB4luhFmGUNXXJhH2jJwZCFB3pIOixv2E3s17GQHBFUOQaISlt7aGcQgqvCaDSxTZJUzlK/QJ1FN8S94MrzQ==
+"@rollup/rollup-win32-ia32-msvc@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz#f4e68265d5c758afd2e1c6ff13319558b0c8a205"
+  integrity sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==
+
+"@rollup/rollup-win32-x64-gnu@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz#54f9e64b3550416c8520e3dc22301ef8e454b37e"
+  integrity sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==
+
+"@rollup/rollup-win32-x64-msvc@4.52.2":
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz#cf83e2c56b581bad4614eeb3d2da5b5917ed34ec"
+  integrity sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==
 
 "@types/estree@1.0.8":
   version "1.0.8"
@@ -341,10 +351,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
-chalk@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
-  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
+chalk@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
 cirru-color@^0.2.4:
   version "0.2.4"
@@ -369,25 +379,25 @@ config-chain@^1.1.11:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-copy-text-to-clipboard@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz#0202b2d9bdae30a49a53f898626dcc3b49ad960b"
-  integrity sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==
+copy-text-to-clipboard@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz#99bc79db3f2d355ec33a08d573aff6804491ddb9"
+  integrity sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==
 
 core-js@^3.1.3:
-  version "3.44.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.44.0.tgz#db4fd4fa07933c1d6898c8b112a1119a9336e959"
-  integrity sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==
+  version "3.45.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.45.1.tgz#5810e04a1b4e9bc5ddaa4dd12e702ff67300634d"
+  integrity sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==
 
-dayjs@^1.11.13:
-  version "1.11.13"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
-  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+dayjs@^1.11.18:
+  version "1.11.18"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.18.tgz#835fa712aac52ab9dec8b1494098774ed7070a11"
+  integrity sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==
 
 debug@4:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
-  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -418,36 +428,36 @@ error@^4.3.0:
     xtend "~4.0.0"
 
 esbuild@^0.25.0:
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.8.tgz#482d42198b427c9c2f3a81b63d7663aecb1dda07"
-  integrity sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.10.tgz#37f5aa5cd14500f141be121c01b096ca83ac34a9"
+  integrity sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==
   optionalDependencies:
-    "@esbuild/aix-ppc64" "0.25.8"
-    "@esbuild/android-arm" "0.25.8"
-    "@esbuild/android-arm64" "0.25.8"
-    "@esbuild/android-x64" "0.25.8"
-    "@esbuild/darwin-arm64" "0.25.8"
-    "@esbuild/darwin-x64" "0.25.8"
-    "@esbuild/freebsd-arm64" "0.25.8"
-    "@esbuild/freebsd-x64" "0.25.8"
-    "@esbuild/linux-arm" "0.25.8"
-    "@esbuild/linux-arm64" "0.25.8"
-    "@esbuild/linux-ia32" "0.25.8"
-    "@esbuild/linux-loong64" "0.25.8"
-    "@esbuild/linux-mips64el" "0.25.8"
-    "@esbuild/linux-ppc64" "0.25.8"
-    "@esbuild/linux-riscv64" "0.25.8"
-    "@esbuild/linux-s390x" "0.25.8"
-    "@esbuild/linux-x64" "0.25.8"
-    "@esbuild/netbsd-arm64" "0.25.8"
-    "@esbuild/netbsd-x64" "0.25.8"
-    "@esbuild/openbsd-arm64" "0.25.8"
-    "@esbuild/openbsd-x64" "0.25.8"
-    "@esbuild/openharmony-arm64" "0.25.8"
-    "@esbuild/sunos-x64" "0.25.8"
-    "@esbuild/win32-arm64" "0.25.8"
-    "@esbuild/win32-ia32" "0.25.8"
-    "@esbuild/win32-x64" "0.25.8"
+    "@esbuild/aix-ppc64" "0.25.10"
+    "@esbuild/android-arm" "0.25.10"
+    "@esbuild/android-arm64" "0.25.10"
+    "@esbuild/android-x64" "0.25.10"
+    "@esbuild/darwin-arm64" "0.25.10"
+    "@esbuild/darwin-x64" "0.25.10"
+    "@esbuild/freebsd-arm64" "0.25.10"
+    "@esbuild/freebsd-x64" "0.25.10"
+    "@esbuild/linux-arm" "0.25.10"
+    "@esbuild/linux-arm64" "0.25.10"
+    "@esbuild/linux-ia32" "0.25.10"
+    "@esbuild/linux-loong64" "0.25.10"
+    "@esbuild/linux-mips64el" "0.25.10"
+    "@esbuild/linux-ppc64" "0.25.10"
+    "@esbuild/linux-riscv64" "0.25.10"
+    "@esbuild/linux-s390x" "0.25.10"
+    "@esbuild/linux-x64" "0.25.10"
+    "@esbuild/netbsd-arm64" "0.25.10"
+    "@esbuild/netbsd-x64" "0.25.10"
+    "@esbuild/openbsd-arm64" "0.25.10"
+    "@esbuild/openbsd-x64" "0.25.10"
+    "@esbuild/openharmony-arm64" "0.25.10"
+    "@esbuild/sunos-x64" "0.25.10"
+    "@esbuild/win32-arm64" "0.25.10"
+    "@esbuild/win32-ia32" "0.25.10"
+    "@esbuild/win32-x64" "0.25.10"
 
 ev-store@^7.0.0:
   version "7.0.0"
@@ -461,10 +471,10 @@ extend@^3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-fdir@^6.4.4, fdir@^6.4.6:
-  version "6.4.6"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.6.tgz#2b268c0232697063111bbf3f64810a2a741ba281"
-  integrity sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 feather-icons@^4.29.2:
   version "4.29.2"
@@ -636,9 +646,9 @@ jws@^4.0.0:
     safe-buffer "^5.0.1"
 
 ky@^1.2.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/ky/-/ky-1.8.2.tgz#161cba76e4a86b43829565b9a9c8d21d03e602db"
-  integrity sha512-XybQJ3d4Ea1kI27DoelE5ZCT3bSJlibYTtQuMsyzKox3TMyayw1asgQdl54WroAm+fIA3ZCr8zXW2RpR7qWVpA==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-1.10.0.tgz#d3b9dc24d723a28cfd0a3254f177d28faa5f961e"
+  integrity sha512-YRPCzHEWZffbfvmRrfwa+5nwBHwZuYiTrfDX0wuhGBPV0pA/zCqcOq93MDssON/baIkpYbvehIX5aLpMxrRhaA==
 
 latest-version@^9.0.0:
   version "9.0.0"
@@ -693,10 +703,10 @@ nanoid@^4.0.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
   integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
 
-nanoid@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.5.tgz#f7597f9d9054eb4da9548cdd53ca70f1790e87de"
-  integrity sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==
+nanoid@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.6.tgz#30363f664797e7d40429f6c16946d6bd7a3f26c9"
+  integrity sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==
 
 next-tick@^0.2.2:
   version "0.2.2"
@@ -737,7 +747,7 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^4.0.2, picomatch@^4.0.3:
+picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -795,33 +805,35 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-rollup@^4.40.0:
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.46.1.tgz#287d07ef0ea17950b348b027c634a9544a1a375f"
-  integrity sha512-33xGNBsDJAkzt0PvninskHlWnTIPgDtTwhg0U38CUoNP/7H6wI2Cz6dUeoNPbjdTdsYTGuiFFASuUOWovH0SyQ==
+rollup@^4.43.0:
+  version "4.52.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.52.2.tgz#43dd135805c919285376634c8520074c5eb7a91a"
+  integrity sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==
   dependencies:
     "@types/estree" "1.0.8"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.46.1"
-    "@rollup/rollup-android-arm64" "4.46.1"
-    "@rollup/rollup-darwin-arm64" "4.46.1"
-    "@rollup/rollup-darwin-x64" "4.46.1"
-    "@rollup/rollup-freebsd-arm64" "4.46.1"
-    "@rollup/rollup-freebsd-x64" "4.46.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.46.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.46.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.46.1"
-    "@rollup/rollup-linux-arm64-musl" "4.46.1"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.46.1"
-    "@rollup/rollup-linux-ppc64-gnu" "4.46.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.46.1"
-    "@rollup/rollup-linux-riscv64-musl" "4.46.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.46.1"
-    "@rollup/rollup-linux-x64-gnu" "4.46.1"
-    "@rollup/rollup-linux-x64-musl" "4.46.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.46.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.46.1"
-    "@rollup/rollup-win32-x64-msvc" "4.46.1"
+    "@rollup/rollup-android-arm-eabi" "4.52.2"
+    "@rollup/rollup-android-arm64" "4.52.2"
+    "@rollup/rollup-darwin-arm64" "4.52.2"
+    "@rollup/rollup-darwin-x64" "4.52.2"
+    "@rollup/rollup-freebsd-arm64" "4.52.2"
+    "@rollup/rollup-freebsd-x64" "4.52.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.52.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.52.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.52.2"
+    "@rollup/rollup-linux-arm64-musl" "4.52.2"
+    "@rollup/rollup-linux-loong64-gnu" "4.52.2"
+    "@rollup/rollup-linux-ppc64-gnu" "4.52.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.52.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.52.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.52.2"
+    "@rollup/rollup-linux-x64-gnu" "4.52.2"
+    "@rollup/rollup-linux-x64-musl" "4.52.2"
+    "@rollup/rollup-openharmony-arm64" "4.52.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.52.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.52.2"
+    "@rollup/rollup-win32-x64-gnu" "4.52.2"
+    "@rollup/rollup-win32-x64-msvc" "4.52.2"
     fsevents "~2.3.2"
 
 safe-buffer@^5.0.1:
@@ -849,13 +861,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-tinyglobby@^0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
-  integrity sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==
+tinyglobby@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
   dependencies:
-    fdir "^6.4.4"
-    picomatch "^4.0.2"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -889,17 +901,17 @@ virtual-dom@^2.1.1:
     x-is-array "0.1.0"
     x-is-string "0.1.0"
 
-vite@^7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-7.0.6.tgz#7866ccb176db4bbeec0adfb3f907f077881591d0"
-  integrity sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==
+vite@^7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.7.tgz#ed3f9f06e21d6574fe1ad425f6b0912d027ffc13"
+  integrity sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==
   dependencies:
     esbuild "^0.25.0"
-    fdir "^6.4.6"
+    fdir "^6.5.0"
     picomatch "^4.0.3"
     postcss "^8.5.6"
-    rollup "^4.40.0"
-    tinyglobby "^0.2.14"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
   optionalDependencies:
     fsevents "~2.3.3"
 


### PR DESCRIPTION
a trick for providing `:examples` which is used in latest Calcit compact file.