### PR TITLE
chore: upgrade Calcit to 0.13.15

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,12 +1,12 @@
 
-{} (:calcit-version |0.13.13)
+{} (:calcit-version |0.13.15)
   :dependencies $ {} (|Cumulo/cumulo-util.calcit |0.0.12)
-    |Respo/alerts.calcit |0.10.16
+    |Respo/alerts.calcit |0.10.17
     |Respo/respo-feather.calcit |0.4.4
     |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-message.calcit |0.0.11
+    |Respo/respo-message.calcit |0.0.12
     |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.67
+    |Respo/respo.calcit |0.16.69
     |calcit-lang/bisection-key |0.0.20
     |calcit-lang/gen-code |0.0.9
     |calcit-lang/recollect |0.0.29

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "vite": "^8.2.1"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.13",
+    "@calcit/procs": "^0.13.15",
     "@google/genai": "^1.37.0",
     "chalk": "^5.6.2",
     "dayjs": "^1.11.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcit/editor@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.13"
+    "@calcit/procs": "npm:^0.13.15"
     "@google/genai": "npm:^1.37.0"
     bottom-tip: "npm:^0.1.5"
     chalk: "npm:^5.6.2"
@@ -28,14 +28,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcit/procs@npm:^0.13.13":
-  version: 0.13.13
-  resolution: "@calcit/procs@npm:0.13.13"
+"@calcit/procs@npm:^0.13.15":
+  version: 0.13.15
+  resolution: "@calcit/procs@npm:0.13.15"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/2f05ccfef08bc971aea97536bf8dd3cb4f1edc67acad8d377b98ecd015a0b01ef674193d92b218c1623b56f772f09e19733b5ec45ab01f4dfba35a4ceadd6295
+  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump calcit-version 0.13.13 → 0.13.15, sync @calcit/procs. Also bumps Respo deps required for the Calcit upgrade: alerts.calcit 0.10.16 → 0.10.17, respo-message.calcit 0.0.11 → 0.0.12, respo.calcit 0.16.67 → 0.16.69. check-only passes.