### PR TITLE
chore: upgrade calcit to 0.13.19

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -10,11 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Enable Corepack
         run: |
@@ -28,6 +28,7 @@ jobs:
 
       - name: Upload web assets
         id: deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: Pendect/action-rsyncer@v2.0.0
         env:
           DEPLOY_KEY: ${{secrets.rsync_private_key}}
@@ -39,4 +40,5 @@ jobs:
           dest: "rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}"
 
       - name: Display status from deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo "${{ steps.deploy.outputs.status }}"

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -4134,7 +4134,7 @@
                         , {}
                     last-k $ last
                       .sort (.to-list ks) &compare
-                  .update self last-k f
+                  update self last-k f
               .update-nth $ fn (self idx f)
                 let
                     ks $ keys
@@ -4144,7 +4144,7 @@
                     last-k $ nth
                       .sort (.to-list ks) &compare
                       , idx
-                  .update self last-k f
+                  update self last-k f
               .update $ fn (self p f)
                 update self :data $ fn (d) (update d p f)
               .assoc-before $ fn (self p x)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,10 +1,12 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.9.13)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
   :entries $ {}
     :client $ {} (:description |) (:init-fn 'app.client/main!) (:mode :native) (:reload-fn 'app.client/reload!)
-      :modules $ [] |recollect/ |respo.calcit/ |respo-ui.calcit/ |respo-message.calcit/ |cumulo-util.calcit/ |ws-edn.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |bisection-key/ |gen-code/
+      :feature-policy $ {}
+      :modules $ [] |recollect/ |respo.calcit/ |respo-ui.calcit/ |respo-message.calcit/ |cumulo-util.calcit/ |ws-edn.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |bisection-key/ |gen-code/ |js-ffi/
       :type-slots $ {}
     :default $ {} (:description |) (:init-fn 'app.server/main!) (:mode :native) (:reload-fn 'app.server/reload!)
+      :feature-policy $ {}
       :modules $ [] |recollect/ |cumulo-util.calcit/ |ws-edn.calcit/ |bisection-key/ |respo-markdown.calcit/
       :type-slots $ {}
   :files $ {}
@@ -19,7 +21,7 @@
           :code $ quote
             defenum %bookmark0 (:def 'String 'String 'Dynamic) (:ns 'String 'Dynamic)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
         |Bookmark $ %{} 'CodeEntry (:doc "|constructor for definition bookmarks, write `Bookmark $ :: :def ns' def' f` to initialize")
           :code $ quote
             defn Bookmark (b)
@@ -73,12 +75,12 @@
                   (:ns ns' f)
                     if (empty? f) nil $ %:: %bookmark :ns ns' (butlast f)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
         |BookmarkTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait BookmarkTrait (:get-focus :fn) (:get-ns :fn) (:is-ns? :fn) (:is-def? :fn) (:update-focus :fn) (:to-path :fn) (:preview :fn) (:get-parent :fn)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.bookmark)
     |app.client $ %{} 'FileEntry
@@ -1373,7 +1375,7 @@
           :code $ quote
             defenum %gen-code-box-action0 $ :plugin 'Fn 'Fn 'Fn
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
         |GenCodeBoxActionImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl GenCodeBoxActionImpl GenCodeBoxActionTrait
@@ -1390,12 +1392,12 @@
                   :plugin render open reset-state
                   reset-state d!
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
         |GenCodeBoxActionTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait GenCodeBoxActionTrait (:render :fn) (:open :fn) (:reset-state :fn)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
         |style-panel $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-panel $ {}
@@ -3405,7 +3407,7 @@
           :code $ quote
             defenum %rename-plugin0 $ :rename-plugin 'Dynamic 'Dynamic 'Dynamic
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
         |RenamePluginImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl RenamePluginImpl RenamePluginTrait
@@ -3429,12 +3431,12 @@
                   :rename-plugin node cursor state
                   d! cursor $ assoc state :show? false
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
         |RenamePluginTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait RenamePluginTrait (:render :fn) (:show :fn) (:close :fn)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
         |use-replace-name-modal $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn use-replace-name-modal (states on-replace)
@@ -4275,7 +4277,7 @@
               .compact $ fn (self) (cirru-compact self)
               .cirru-kind $ fn (_self) :expr
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
         |CirruLeaf $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def CirruLeaf $ impl-traits
@@ -4298,7 +4300,7 @@
                   , false
               .cirru-kind $ fn (_self) :leaf
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
         |CodeEntry $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def CodeEntry $ defstruct :CodeEntry (:doc 'String) (:code 'Dynamic) (:examples 'List)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -315,7 +315,7 @@
             defn expr-many-items? (x size)
               if (expr? x)
                 let
-                    d $ &struct:get x :data
+                    d $ :data (assert-type x 'app.schema/CirruExpr)
                   or
                     > (count d) size
                     any? (vals d) expr?
@@ -919,9 +919,9 @@
                               option:unwrap-or (get d :writer) {}
                           (:editor d)
                             comp-page-editor (>> states :editor)
-                              option:unwrap-or (&struct:get writer :stack) []
+                              option:unwrap-or (get writer :stack) []
                               , d
-                                option:unwrap-or (&struct:get writer :pointer) 0
+                                option:unwrap-or (get writer :pointer) 0
                                 , picker-mode? theme
                           (:search d)
                             comp-search (>> states :search) d
@@ -1136,7 +1136,10 @@
               let
                   focused? $ = focus coord
                   focus-in? $ coord-contains? focus coord
-                  sorted-children $ -> (&struct:get expr :data) (.to-list) (.sort-by first)
+                  sorted-children $ ->
+                    :data $ assert-type expr 'app.schema/CirruExpr
+                    .to-list
+                    .sort-by first
                   first-id $ if (empty? sorted-children) nil
                     first $ option:unwrap-or (first sorted-children) []
                   last-id $ if (empty? sorted-children) nil
@@ -3214,7 +3217,9 @@
                     if
                       and (struct? target-node)
                         = :Leaf $ &struct:get-name target-node
-                      &struct:get target-node :text
+                      option:unwrap-or
+                        get (unsafe-coerce target-node 'Dynamic) :text
+                        , nil
                       , nil
                     , nil
                   hint-func $ fn (x)
@@ -4114,10 +4119,10 @@
               .nth $ fn (self idx)
                 let
                     d $ option:unwrap-or
-                      get (assert-type self 'app.schema/CirruExpr) :data
+                        :data $ assert-type self 'app.schema/CirruExpr
                       , {}
                     p $ .unwrap (bisection/key-nth d idx)
-                  get self p
+                  get d p
               .append $ fn (self x)
                 update self :data $ fn (d) (bisection/assoc-append d x)
               .prepend $ fn (self x)
@@ -4130,7 +4135,7 @@
                 let
                     ks $ keys
                       option:unwrap-or
-                        get (assert-type self 'app.schema/CirruExpr) :data
+                          :data $ assert-type self 'app.schema/CirruExpr
                         , {}
                     last-k $ last
                       .sort (.to-list ks) &compare
@@ -4139,7 +4144,7 @@
                 let
                     ks $ keys
                       option:unwrap-or
-                        get (assert-type self 'app.schema/CirruExpr) :data
+                          :data $ assert-type self 'app.schema/CirruExpr
                         , {}
                     last-k $ nth
                       .sort (.to-list ks) &compare
@@ -4181,7 +4186,7 @@
                 if (.= self x) pp $ let
                     pairs $ .to-list
                       option:unwrap-or
-                        get (assert-type self 'app.schema/CirruExpr) :data
+                          :data $ assert-type self 'app.schema/CirruExpr
                         , {}
                   apply-args (pairs)
                     fn (ps)
@@ -4206,7 +4211,7 @@
                 if (.= self x) pp $ let
                     pairs $ .to-list
                       option:unwrap-or
-                        get (assert-type self 'app.schema/CirruExpr) :data
+                          :data $ assert-type self 'app.schema/CirruExpr
                         , {}
                   apply-args (pairs)
                     fn (ps)
@@ -4225,7 +4230,7 @@
                                     and $ = :Leaf (&struct:get-name q0)
                                     =
                                       option:unwrap-or
-                                        get (assert-type q0 'app.schema/CirruLeaf) :text
+                                        get (unsafe-coerce q0 'Dynamic) :text
                                         , nil
                                       , follow
                                   , false
@@ -4283,7 +4288,13 @@
             defimpl CirruLeafMethods :CirruLeafTrait
               .= $ fn (self x)
                 if (&struct:matches? self x)
-                  = (get self :text) (get x :text)
+                  =
+                    option:unwrap-or
+                      get (unsafe-coerce self 'Dynamic) :text
+                      , |
+                    option:unwrap-or
+                      get (unsafe-coerce x 'Dynamic) :text
+                      , |
                   , false
               .cirru-kind $ fn (_self) :leaf
           :examples $ []
@@ -4310,11 +4321,11 @@
                 and (struct? x)
                   = :Leaf $ &struct:get-name x
                 option:unwrap-or
-                  get (assert-type x 'app.schema/CirruLeaf) :text
-                  , nil
+                  get (unsafe-coerce x 'Dynamic) :text
+                  , |
                 ->
                   option:unwrap-or
-                    get (assert-type x 'app.schema/CirruExpr) :data
+                      :data $ assert-type x 'app.schema/CirruExpr
                     , {}
                   .to-list
                   .sort-by first
@@ -5602,7 +5613,7 @@
                                       swap! *usages &map:assoc reference $ #{} entry
                                     swap! *entry-deps include reference
                                 parse-bookmarks-collect!
-                                  tree->cirru $ &struct:get v :code
+                                  tree->cirru $ option:unwrap-or (get v :code) nil
                                   , local-defs import-rules this-ns this-def collect!
                                 swap! *deps assoc entry @*entry-deps
                 :: :deps @*deps @*usages
@@ -5906,18 +5917,14 @@
                       let[] (k v) pair $ [] k (call-replace-expr v from to)
                     filter-not $ fn (pair)
                       let[] (k v) pair $ and (leaf? v)
-                        blank? $ option:unwrap-or
-                          get (assert-type v 'app.schema/CirruLeaf) :text
-                          , nil
+                        blank? $ :text (assert-type v 'app.schema/CirruLeaf)
                     pairs-map
                 cond
                     =
-                      option:unwrap-or
-                        get (assert-type expr 'app.schema/CirruLeaf) :text
-                        , nil
+                      :text $ assert-type expr 'app.schema/CirruLeaf
                       , from
                     assoc expr :text to
-                  (= (option:unwrap-or (get (assert-type expr 'app.schema/CirruLeaf) :text) nil) (str |@ from))
+                  (= (:text (assert-type expr 'app.schema/CirruLeaf)) (str |@ from))
                     assoc expr :text $ str |@ to
                   true expr
           :examples $ []
@@ -6359,7 +6366,7 @@
                         next-id $ .unwrap
                           key-nth
                             option:unwrap-or
-                              get (assert-type expr 'app.schema/CirruExpr) :data
+                                :data $ assert-type expr 'app.schema/CirruExpr
                               , nil
                             , 1
                       -> db
@@ -6383,7 +6390,7 @@
                         next-id $ .unwrap
                           key-nth
                             option:unwrap-or
-                              get (assert-type expr 'app.schema/CirruExpr) :data
+                                :data $ assert-type expr 'app.schema/CirruExpr
                               , nil
                             , 1
                         files $ get db :files
@@ -6554,11 +6561,11 @@
                     fn (expr)
                       if
                         = 1 $ option:unwrap-or
-                          get (assert-type expr 'app.schema/CirruExpr) :data
+                            :data $ assert-type expr 'app.schema/CirruExpr
                           , {}
                         nth
                           option:unwrap-or
-                            get (assert-type expr 'app.schema/CirruExpr) :data
+                              :data $ assert-type expr 'app.schema/CirruExpr
                             , {}
                           , 1
                         , expr
@@ -6579,7 +6586,7 @@
                                 , {}
                           children $ ->
                             option:unwrap-or
-                              get (assert-type expr 'app.schema/CirruExpr) :data
+                                :data $ assert-type expr 'app.schema/CirruExpr
                               , {}
                             .to-list
                             .sort-by first
@@ -6620,7 +6627,7 @@
                       option:unwrap-or
                         first $ vals
                           option:unwrap-or
-                            get (assert-type expr 'app.schema/CirruExpr) :data
+                              :data $ assert-type expr 'app.schema/CirruExpr
                             , {}
                         , expr
                     update-in
@@ -6643,9 +6650,7 @@
                 -> db $ update-in data-path
                   fn (leaf)
                     let
-                        leaf-at $ option:unwrap-or
-                          get (assert-type leaf 'app.schema/CirruLeaf) :at
-                          , 0
+                        leaf-at $ :at (assert-type leaf 'app.schema/CirruLeaf)
                         op-at $ get op-data :at
                         op-text $ get op-data :text
                       if
@@ -7529,8 +7534,12 @@
         |tree->cirru $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn tree->cirru (x)
-              if (leaf? x) (&struct:get x :text)
-                -> x (&struct:get :data) (&map:to-list) (&list:sort-by first)
+              if (leaf? x)
+                :text $ assert-type x 'app.schema/CirruLeaf
+                ->
+                  :data $ assert-type x 'app.schema/CirruExpr
+                  &map:to-list
+                  &list:sort-by first
                   map $ fn (entry)
                     tree->cirru $ &list:nth entry 1
           :examples $ []

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,13 +1,14 @@
 
-{} (:calcit-version |0.13.19)
+{} (:calcit-version |0.13.27)
+  :version |0.9.14
   :dependencies $ {} (|Cumulo/cumulo-util.calcit |0.0.12)
     |Respo/alerts.calcit |0.10.17
     |Respo/respo-feather.calcit |0.4.4
     |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-message.calcit |0.0.12
-    |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.72
+    |Respo/respo-message.calcit |0.0.13
+    |Respo/respo-ui.calcit |0.7.8
+    |Respo/respo.calcit |0.16.78
     |calcit-lang/bisection-key |0.0.20
     |calcit-lang/gen-code |0.0.9
-    |calcit-lang/recollect |0.0.29
+    |calcit-lang/recollect |0.0.30
     |mvc-works/ws-edn.calcit |0.0.16

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,12 +1,12 @@
 
-{} (:calcit-version |0.13.15)
+{} (:calcit-version |0.13.19)
   :dependencies $ {} (|Cumulo/cumulo-util.calcit |0.0.12)
     |Respo/alerts.calcit |0.10.17
     |Respo/respo-feather.calcit |0.4.4
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-message.calcit |0.0.12
     |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.69
+    |Respo/respo.calcit |0.16.72
     |calcit-lang/bisection-key |0.0.20
     |calcit-lang/gen-code |0.0.9
     |calcit-lang/recollect |0.0.29

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/editor",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Structural Editor for Calcit Language",
   "bin": {
     "ct": "server.mjs"
@@ -28,7 +28,7 @@
     "vite": "^8.2.1"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.19",
+    "@calcit/procs": "^0.13.27",
     "@google/genai": "^1.37.0",
     "chalk": "^5.6.2",
     "dayjs": "^1.11.19",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "vite": "^8.2.1"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.15",
+    "@calcit/procs": "^0.13.19",
     "@google/genai": "^1.37.0",
     "chalk": "^5.6.2",
     "dayjs": "^1.11.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcit/editor@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.19"
+    "@calcit/procs": "npm:^0.13.27"
     "@google/genai": "npm:^1.37.0"
     bottom-tip: "npm:^0.1.5"
     chalk: "npm:^5.6.2"
@@ -28,14 +28,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcit/procs@npm:^0.13.19":
-  version: 0.13.19
-  resolution: "@calcit/procs@npm:0.13.19"
+"@calcit/procs@npm:^0.13.27":
+  version: 0.13.27
+  resolution: "@calcit/procs@npm:0.13.27"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
+  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcit/editor@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.15"
+    "@calcit/procs": "npm:^0.13.19"
     "@google/genai": "npm:^1.37.0"
     bottom-tip: "npm:^0.1.5"
     chalk: "npm:^5.6.2"
@@ -28,14 +28,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcit/procs@npm:^0.13.15":
-  version: 0.13.15
-  resolution: "@calcit/procs@npm:0.13.15"
+"@calcit/procs@npm:^0.13.19":
+  version: 0.13.19
+  resolution: "@calcit/procs@npm:0.13.19"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
+  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Per `cr docs read upgrade`:
- `caps upgrade --all`: `:calcit-version` -> 0.13.19; pinned deps bumped to latest tags
- `@calcit/procs` synced to ^0.13.19 in package.json / yarn.lock
- modules re-synced via `caps`

deps.cirru audit: all deps pinned to versions; no :dev-dependencies section.