### PR TITLE
fix: complete Calcit CLI migration

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -29,7 +29,7 @@ jobs:
           corepack prepare yarn@4.12.0 --activate
           yarn --version
 
-      - uses: calcit-lang/setup-calcit@v1
+      - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
 
       - run: caps --ci && yarn install --immutable && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -29,7 +29,7 @@ jobs:
           corepack prepare yarn@4.12.0 --activate
           yarn --version
 
-      - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
+      - uses: calcit-lang/setup-calcit@3b5843cb725963bb4ee158cfe49dad877134963e # v1
 
       - run: caps --ci && yarn install --immutable && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -22,7 +22,7 @@ jobs:
           corepack prepare yarn@4.12.0 --activate
           yarn --version
 
-      - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
+      - uses: calcit-lang/setup-calcit@3b5843cb725963bb4ee158cfe49dad877134963e # v1
 
       - run: caps --ci && yarn install --immutable && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -22,7 +22,7 @@ jobs:
           corepack prepare yarn@4.12.0 --activate
           yarn --version
 
-      - uses: calcit-lang/setup-calcit@v1
+      - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
 
       - run: caps --ci && yarn install --immutable && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -7561,7 +7561,7 @@
                         target $ get latest-files filter-ns
                       if (some? target) (assoc old-files filter-ns target) (dissoc old-files filter-ns)
                     , latest-files
-                  calcit-data $ {} (:package pkg) (:about "|file is generated - never edit directly; learn cr edit/tree workflows before changing")
+                  calcit-data $ {} (:package pkg) (:about "|file is generated - never edit directly; learn calcit edit/tree workflows before changing")
                     :configs $ {}
                       :init-fn $ option:unwrap-or (get configs :init-fn) nil
                       :reload-fn $ option:unwrap-or (get configs :reload-fn) nil

--- a/history/2026082300-fix-calcit-guidance.md
+++ b/history/2026082300-fix-calcit-guidance.md
@@ -1,0 +1,4 @@
+# 2026-08-23 00:00 Fix Calcit guidance and action pinning
+
+- 将 snapshot 内嵌提示中的 `cr` 改为 `calcit`。
+- 将 upload 与 npm-publish workflow 的 setup-calcit 固定到已验证的 commit SHA。


### PR DESCRIPTION
Follow-up to the merged Calcit 0.13.29 upgrade. Replace remaining cr commands with calcit, pin setup-calcit to an immutable SHA, and keep calcit.cirru guidance current. Verified with calcit 0.13.29 and check-only.