### PR TITLE
chore: upgrade editor to Calcit 0.13.31

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,6 @@
 /webpack.config.js
 /index.html
 /client.js
-compact.cirru
 /.gitattributes
 .compact-inc.cirru
 .calcit-error.cirru

--- a/2026082222-upgrade-calcit-01331.md
+++ b/2026082222-upgrade-calcit-01331.md
@@ -1,0 +1,5 @@
+# Upgrade Calcit to 0.13.31
+
+- Updated Calcit and `@calcit/procs` to 0.13.31.
+- Updated bisection-key to 0.0.21 and recollect to 0.0.32.
+- Bumped editor to 0.9.15 for a stable tag.

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,6 +1,6 @@
 
-{} (:calcit-version |0.13.29)
-  :version |0.9.14
+{} (:calcit-version |0.13.31)
+  :version |0.9.15
   :dependencies $ {} (|Cumulo/cumulo-util.calcit |0.0.13)
     |Respo/alerts.calcit |0.10.19
     |Respo/respo-feather.calcit |0.4.4
@@ -8,7 +8,7 @@
     |Respo/respo-message.calcit |0.0.13
     |Respo/respo-ui.calcit |0.7.9
     |Respo/respo.calcit |0.16.81
-    |calcit-lang/bisection-key |0.0.20
+    |calcit-lang/bisection-key |0.0.21
     |calcit-lang/gen-code |0.0.9
-    |calcit-lang/recollect |0.0.30
+    |calcit-lang/recollect |0.0.32
     |mvc-works/ws-edn.calcit |0.0.16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/editor",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Structural Editor for Calcit Language",
   "bin": {
     "ct": "server.mjs"
@@ -28,7 +28,7 @@
     "vite": "^8.2.1"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.29",
+    "@calcit/procs": "^0.13.31",
     "@google/genai": "^1.37.0",
     "chalk": "^5.6.2",
     "dayjs": "^1.11.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@calcit/editor@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.29"
+    "@calcit/procs": "npm:^0.13.31"
     "@google/genai": "npm:^1.37.0"
     bottom-tip: "npm:^0.1.5"
     chalk: "npm:^5.6.2"
@@ -28,14 +28,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@calcit/procs@npm:^0.13.29":
-  version: 0.13.29
-  resolution: "@calcit/procs@npm:0.13.29"
+"@calcit/procs@npm:^0.13.31":
+  version: 0.13.31
+  resolution: "@calcit/procs@npm:0.13.31"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
+  checksum: 10c0/7114144cf01c890b05538598b1ab2b2b9f201aa477ac17c4f708f3abfe49beb0a3889e305b08bce81b096a75d46f420b2ee005351a0ab1d6fad54f6655c79406
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade editor and its stable Calcit module dependencies, release 0.9.15.\n\nActions must pass and all review comments must be resolved before merge.